### PR TITLE
Append API paths to the base URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,7 +23,6 @@ func NewClient(instance string) (Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	tgt.Path = ""
 
 	options := []httptransport.ClientOption{}
 

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -41,7 +41,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		SilenceUsage:      true,
 		PersistentPreRunE: opts.PersistentPreRunE,
 	}
-	cmd.PersistentFlags().StringVarP(&opts.URL, "url", "u", "http://localhost:3030/v0",
+	cmd.PersistentFlags().StringVarP(&opts.URL, "url", "u", "http://localhost:3030",
 		fmt.Sprintf("base URL of the fluxd API server; you can also set the environment variable %s", EnvVariableURL))
 
 	cmd.AddCommand(

--- a/transport.go
+++ b/transport.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -323,7 +324,7 @@ func encodeImagesRequest(ctx context.Context, req *http.Request, request interfa
 	r := request.(imagesRequest)
 
 	req.Method = "GET"
-	req.URL.Path = "/v0/images/" + r.Repository
+	req.URL.Path = path.Join(req.URL.Path, "/v0/images/"+r.Repository)
 
 	return nil
 }
@@ -334,7 +335,7 @@ func encodeServiceImagesRequest(ctx context.Context, req *http.Request, request 
 	values.Set("namespace", r.Namespace)
 
 	req.Method = "GET"
-	req.URL.Path = fmt.Sprintf("/v0/service/%s/images", r.Service)
+	req.URL.Path = path.Join(req.URL.Path, fmt.Sprintf("/v0/service/%s/images", r.Service))
 	req.URL.RawQuery = values.Encode()
 
 	return nil
@@ -346,7 +347,7 @@ func encodeServicesRequest(ctx context.Context, req *http.Request, request inter
 	values.Set("namespace", r.Namespace)
 
 	req.Method = "GET"
-	req.URL.Path = "/v0/services"
+	req.URL.Path = path.Join(req.URL.Path, "/v0/services")
 	req.URL.RawQuery = values.Encode()
 
 	return nil
@@ -358,7 +359,8 @@ func encodeHistoryRequest(ctx context.Context, req *http.Request, request interf
 	values.Set("namespace", r.Namespace)
 
 	req.Method = "GET"
-	req.URL.Path = fmt.Sprintf("/v0/history/%s", r.Service)
+	// NB be careful here: Join will strip a trailing slash
+	req.URL.Path = fmt.Sprintf(path.Join(req.URL.Path, "/v0/history/%s"), r.Service)
 	req.URL.RawQuery = values.Encode()
 
 	return nil
@@ -372,7 +374,7 @@ func encodeReleaseRequest(ctx context.Context, req *http.Request, request interf
 	values.Set("updatePeriod", r.UpdatePeriod.String())
 
 	req.Method = "POST"
-	req.URL.Path = "/v0/release"
+	req.URL.Path = path.Join(req.URL.Path, "/v0/release")
 	req.URL.RawQuery = values.Encode()
 	req.Body = ioutil.NopCloser(bytes.NewReader(r.NewDef))
 
@@ -386,7 +388,7 @@ func encodeAutomateRequest(ctx context.Context, req *http.Request, request inter
 	values.Set("service", r.Service)
 
 	req.Method = "POST"
-	req.URL.Path = "/v0/automate"
+	req.URL.Path = path.Join(req.URL.Path, "/v0/automate")
 	req.URL.RawQuery = values.Encode()
 
 	return nil
@@ -399,7 +401,7 @@ func encodeDeautomateRequest(ctx context.Context, req *http.Request, request int
 	values.Set("service", r.Service)
 
 	req.Method = "POST"
-	req.URL.Path = "/v0/deautomate"
+	req.URL.Path = path.Join(req.URL.Path, "/v0/deautomate")
 	req.URL.RawQuery = values.Encode()
 
 	return nil


### PR DESCRIPTION
.. instead of overwriting it. This means it can be used via a gateway
or proxy or what-have-you.
