### PR TITLE
Correct several problems with fluxy-in-k8s and document

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,34 +13,75 @@ make clean build
 which will build the image in minikube's Docker daemon,
  thus making it available to Kubernetes.
 
-The file `fluxy-deployment.yaml` contains a Kubernetes deployment configuration
- that runs the latest image of Fluxy.
+## Creating a key for automation
+
+The automation component mutates a Git repository containing your
+Kubernetes config, which requires an SSH access key.  That private key
+is stored as a Kubernetes secret named `fluxy-repo-key`.
+
+Here is an example of setting this up for the `helloworld` example in
+the fluxy repository.
+
+Fork the fluxy repository on github (you may also wish to rename it,
+e.g., to `fluxy-testconf`). Now, we're going to add a deploy key so
+fluxy can push to that repo. Generate a key in the console:
+
+```
+ssh-keygen -t rsa -b 4096 -f id-rsa-fluxy
+```
+
+This makes a private key file (`id-rsa-fluxy`) which we'll supply to
+Fluxy in a minute, and a public key file (`id-rsa-fluxy.pub`) which
+we'll now give to Github.
+
+On the Github page for your forked repo, go to the settings and find
+the "Deploy keys" page. Add one, and paste in the contents of the
+`id-rsa-fluxy.pub` file -- the public key.
+
+Kubernetes wants the private key in the form of a secret. To create that,
+
+```
+kubectl delete secret fluxy-repo-key
+kubectl create secret generic fluxy-repo-key --from-file=id-rsa=id-rsa-fluxy
+```
+
+## Customising the deployment config
+
+The file `fluxy-deployment.yaml` contains a Kubernetes deployment
+configuration that runs the latest image of Fluxy.
+
+You will need to change at least the repository arguments, to use your
+Github repo. Adapt these lines:
+
+```
+        - --repo-url=git@github.com:squaremo/fluxy-testdata
+        - --repo-key=/var/run/secrets/fluxy/key/id-rsa
+        - --repo-path=testdata
+```
+
+The last, `--repo-path`, refers to the directory _within_ the
+repository containing the configuration files (the seeting above is
+correct if you have forked the fluxy repo as above).
+
+You can create the deployment now:
 
 ```
 kubectl create -f fluxy-deployment.yaml
 ```
 
-To make the pod accessible to `fluxctl`, you can port forward:
+To make the pod accessible to `fluxctl`, you can create a service for Fluxy and use the Kubernetes API proxy to access it:
 
 ```
-kubectl port-forward $(kubectl get pods | grep fluxy | awk '{print $1}') 3030:3030
+kubectl create -f fluxy-service.yaml
+kubectl proxy &
+export FLUX_URL=http://localhost:8001/api/v1/proxy/namespaces/default/services/fluxy
 ```
 
 This will work with the default settings of `fluxctl`,
  and is especially handy with minikube.
 
-To force Kubernetes to run the latest image, kill the pod:
+To force Kubernetes to run the latest image after a rebuild, kill the pod:
 
 ```
 kubectl get pods | grep fluxy | awk '{ print $1 }' | xargs kubectl delete pod
-```
-
-## Automation and secrets
-
-The automation component mutates a Git repository, which requires an SSH access key.
-That private key is stored as a Kubernetes secret named `fluxy-repo-key`.
-
-```
-kubectl delete secret fluxy-repo-key
-kubectl create secret generic fluxy-repo-key --from-file=id-rsa=/path/to/id_rsa
 ```

--- a/deploy/fluxy-deployment.yaml
+++ b/deploy/fluxy-deployment.yaml
@@ -31,6 +31,6 @@ spec:
         - --kubernetes-bearer-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --database-driver=ql
         - --database-source=file://history.db
-        - --repo-url=git@github.com:peterbourgon/dumbconf
+        - --repo-url=git@github.com:squaremo/fluxy-testdata
         - --repo-key=/var/run/secrets/fluxy/key/id-rsa
-        - --repo-path="/"
+        - --repo-path=testdata

--- a/deploy/fluxy-service.yaml
+++ b/deploy/fluxy-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluxy
+spec:
+  ports:
+    - port: 3030
+  selector:
+    name: fluxy

--- a/docker/Dockerfile.fluxy
+++ b/docker/Dockerfile.fluxy
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 WORKDIR /home/flux
-RUN apk add --no-cache git
+RUN apk add --no-cache git openssh
 ADD ./kubectl /home/flux/
 COPY ./ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY ./fluxd /home/flux/


### PR DESCRIPTION
The image did not include ssh, which git wants to be present.

If you mount a secret to get the private key, it will have the wrong
permissions and ssh will ignore it. So, copy the key into the working
directory, and make sure it has the right permissions.

Elaborated instructions on making keys for trying it out with a
config.
