### PR TITLE
Rejig post newapi

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,11 +20,11 @@ func NewClient(c *http.Client, router *mux.Router, endpoint string) Service {
 	}
 }
 
-func (c *client) ListServices() ([]ServiceDescription, error) {
+func (c *client) ListServices() ([]ServiceStatus, error) {
 	return invokeListServices(c.client, c.router, c.endpoint)
 }
 
-func (c *client) ListImages(s ServiceSpec) ([]ImageDescription, error) {
+func (c *client) ListImages(s ServiceSpec) ([]ImageStatus, error) {
 	return invokeListImages(c.client, c.router, c.endpoint, s)
 }
 

--- a/cmd/fluxctl/args.go
+++ b/cmd/fluxctl/args.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/weaveworks/fluxy"
+)
+
+func parseServiceOption(s string) (flux.ServiceSpec, error) {
+	if s == "" {
+		return flux.ServiceSpecAll, nil
+	}
+	return flux.ParseServiceSpec(s)
+}
+
+func parseImageOption(i string) (flux.ImageSpec, error) {
+	if i == "" {
+		return flux.ImageSpecLatest, nil
+	}
+	return flux.ParseImageSpec(i), nil
+}

--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/fluxy"
+)
 
 type serviceAutomateOpts struct {
 	*serviceOpts
@@ -31,5 +35,11 @@ func (opts *serviceAutomateOpts) RunE(_ *cobra.Command, args []string) error {
 	if opts.service == "" {
 		return newUsageError("-s, --service is required")
 	}
-	return opts.Fluxd.Automate(opts.namespace, opts.service)
+
+	serviceID, err := flux.ParseServiceID(opts.service)
+	if err != nil {
+		return err
+	}
+
+	return opts.Fluxd.Automate(serviceID)
 }

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/fluxy"
+)
 
 type serviceDeautomateOpts struct {
 	*serviceOpts
@@ -31,5 +35,11 @@ func (opts *serviceDeautomateOpts) RunE(_ *cobra.Command, args []string) error {
 	if opts.service == "" {
 		return newUsageError("-s, --service is required")
 	}
-	return opts.Fluxd.Deautomate(opts.namespace, opts.service)
+
+	serviceID, err := flux.ParseServiceID(opts.service)
+	if err != nil {
+		return err
+	}
+
+	return opts.Fluxd.Deautomate(serviceID)
 }

--- a/cmd/fluxctl/error.go
+++ b/cmd/fluxctl/error.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type usageError struct {
+	error
+}
+
+func newUsageError(msg string) usageError {
+	return usageError{error: errors.New(msg)}
+}
+
+func mutuallyExclusive(opt1, opt2 string) error {
+	return newUsageError(fmt.Sprintf("please supply only one of %s or %s", opt1, opt2))
+}
+
+func exactlyOne(opts ...string) error {
+	var allButLast string
+	if len(opts) > 2 {
+		allButLast = strings.Join(opts[:len(opts)-1], ", ") + ","
+	} else {
+		allButLast = opts[0]
+	}
+	return newUsageError("please supply exactly one of " + allButLast + " or " + opts[len(opts)-1])
+}
+
+var (
+	errorWantedNoArgs = newUsageError("expected no (non-flag) arguments")
+)

--- a/cmd/fluxctl/format.go
+++ b/cmd/fluxctl/format.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+func newTabwriter() *tabwriter.Writer {
+	return tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+}
+
+func makeExample(examples ...string) string {
+	var buf bytes.Buffer
+	for _, ex := range examples {
+		fmt.Fprintf(&buf, "  "+ex+"\n")
+	}
+	return strings.TrimSuffix(buf.String(), "\n")
+}

--- a/cmd/fluxctl/history_cmd.go
+++ b/cmd/fluxctl/history_cmd.go
@@ -34,23 +34,22 @@ func (opts *serviceHistoryOpts) RunE(_ *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return errorWantedNoArgs
 	}
-	events, err := opts.Fluxd.History(opts.namespace, opts.service)
+
+	service, err := parseServiceOption(opts.service)
+	if err != nil {
+		return err
+	}
+
+	events, err := opts.Fluxd.History(service)
 	if err != nil {
 		return err
 	}
 
 	out := newTabwriter()
 
-	if opts.service != "" {
-		fmt.Fprintln(out, "TIME\tMESSAGE")
-		for _, event := range events {
-			fmt.Fprintf(out, "%s\t%s\n", event.Stamp.Format(time.RFC822), event.Msg)
-		}
-	} else {
-		fmt.Fprintln(out, "TIME\tSERVICE\tMESSAGE")
-		for _, e := range events {
-			fmt.Fprintf(out, "%s\t%s\t%s\n", e.Stamp.Format(time.RFC822), e.Service, e.Msg)
-		}
+	fmt.Fprintln(out, "TIME\tTYPE\tMESSAGE")
+	for _, event := range events {
+		fmt.Fprintf(out, "%s\t%s\n", event.Stamp.Format(time.RFC822), event.Type, event.Data)
 	}
 
 	out.Flush()

--- a/cmd/fluxctl/main.go
+++ b/cmd/fluxctl/main.go
@@ -1,5 +1,15 @@
 package main
 
+import "os"
+
 func main() {
-	// FIXME
+	rootCmd := newRoot().Command()
+	if cmd, err := rootCmd.ExecuteC(); err != nil {
+		switch err.(type) {
+		case usageError:
+			cmd.Println("")
+			cmd.Println(cmd.UsageString())
+		}
+		os.Exit(1)
+	}
 }

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -22,7 +23,6 @@ type rootOpts struct {
 
 type serviceOpts struct {
 	*rootOpts
-	namespace string
 }
 
 func newService(parent *rootOpts) *serviceOpts {
@@ -54,7 +54,6 @@ func (opts *rootOpts) Command() *cobra.Command {
 		fmt.Sprintf("base URL of the fluxd API server; you can also set the environment variable %s", EnvVariableURL))
 
 	svcopts := newService(opts)
-	cmd.PersistentFlags().StringVarP(&svcopts.namespace, "namespace", "n", "default", "namespace of service(s) to operate on")
 
 	cmd.AddCommand(
 		newServiceShow(svcopts).Command(),
@@ -72,7 +71,7 @@ func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 	var err error
 
 	opts.URL = getFromEnvIfNotSet(cmd.Flags(), "url", EnvVariableURL, opts.URL)
-	opts.Fluxd, err = flux.NewClient(opts.URL)
+	opts.Fluxd = flux.NewClient(http.DefaultClient, flux.NewRouter(), opts.URL)
 	return err
 }
 

--- a/service.go
+++ b/service.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Service interface {
-	ListServices() ([]ServiceDescription, error)
-	ListImages(ServiceSpec) ([]ImageDescription, error)
+	ListServices() ([]ServiceStatus, error)
+	ListImages(ServiceSpec) ([]ImageStatus, error)
 	Release(ServiceSpec, ImageSpec, ReleaseKind) ([]ReleaseAction, error)
 	Automate(ServiceID) error
 	Deautomate(ServiceID) error
@@ -122,9 +122,16 @@ func ParseImageSpec(s string) ImageSpec {
 	return ImageSpec(ParseImageID(s))
 }
 
-type ServiceDescription struct {
+type ImageStatus struct {
 	ID         ServiceID
 	Containers []Container
+}
+
+type ServiceStatus struct {
+	ID         ServiceID
+	Containers []Container
+	Status     string
+	Automated  bool
 }
 
 type Container struct {

--- a/transport.go
+++ b/transport.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -50,7 +51,7 @@ func handleListServices(s Service) http.Handler {
 	})
 }
 
-func invokeListServices(client *http.Client, router *mux.Router, endpoint string) ([]ServiceDescription, error) {
+func invokeListServices(client *http.Client, router *mux.Router, endpoint string) ([]ServiceStatus, error) {
 	u, err := makeURL(endpoint, router, "ListServices")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
@@ -66,8 +67,8 @@ func invokeListServices(client *http.Client, router *mux.Router, endpoint string
 		return nil, errors.Wrap(err, "executing HTTP request")
 	}
 
-	var res []ServiceDescription
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+	var res []ServiceStatus
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, errors.Wrap(err, "decoding response from server")
 	}
 	return res, nil
@@ -94,7 +95,7 @@ func handleListImages(s Service) http.Handler {
 	})
 }
 
-func invokeListImages(client *http.Client, router *mux.Router, endpoint string, s ServiceSpec) ([]ImageDescription, error) {
+func invokeListImages(client *http.Client, router *mux.Router, endpoint string, s ServiceSpec) ([]ImageStatus, error) {
 	u, err := makeURL(endpoint, router, "ListImages", "service", string(s))
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
@@ -110,8 +111,8 @@ func invokeListImages(client *http.Client, router *mux.Router, endpoint string, 
 		return nil, errors.Wrap(err, "executing HTTP request")
 	}
 
-	var res []ImageDescription
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+	var res []ImageStatus
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, errors.Wrap(err, "decoding response from server")
 	}
 	return res, nil
@@ -168,7 +169,7 @@ func invokeRelease(client *http.Client, router *mux.Router, endpoint string, s S
 	}
 
 	var res []ReleaseAction
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, errors.Wrap(err, "decoding response from server")
 	}
 	return res, nil
@@ -289,7 +290,7 @@ func invokeHistory(client *http.Client, router *mux.Router, endpoint string, s S
 	}
 
 	var res []HistoryEntry
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, errors.Wrap(err, "decoding response from server")
 	}
 
@@ -324,7 +325,7 @@ func makeURL(endpoint string, router *mux.Router, routeName string, urlParams ..
 		v.Set(urlParams[i], urlParams[i+1])
 	}
 
-	endpointURL.Path = routeURL.Path
+	endpointURL.Path = path.Join(endpointURL.Path, routeURL.Path)
 	endpointURL.RawQuery = v.Encode()
 	return endpointURL, nil
 }


### PR DESCRIPTION
Reinstates the fluxctl code, rearranges it and rejigs it for the new service API.

Involves some reworking the service API as well, to provide the commands with the information they need.

Ideally, once merged, the whole should be given a `git rebase -i` to elide the commit that removes/empties all the files.
