### PR TITLE
Return blank Repository if tags lookup fails

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -90,6 +90,14 @@ func (c *Client) GetRepository(repository string) (*Repository, error) {
 
 	tags, err := client.Repository.ListTags(hostlessImageName, auth)
 	if err != nil {
+		if regerr, ok := err.(dockerregistry.RegistryError); ok {
+			if regerr.Code == 404 {
+				c.Logger.Log("registry-err", regerr)
+				return &Repository{
+					Name: repository,
+				}, nil
+			}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Some image repositories don't seem to have an entry in the Docker
registry v1 API, and return a 404. For the minute, gloss over these by
just returning a "blank" image.

We could use the v2 API, but it does not record created times for
tags, so we'd lose the ability to order them. (There may be another
temporary solution available via backwards compatibility information
that is exposed in the v2 API).
