### PR TITLE
Don't print / if registry is empty

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -55,7 +55,10 @@ func (opts *serviceShowOpts) RunE(_ *cobra.Command, args []string) error {
 		for _, container := range service.Containers {
 			containerName := container.Name
 			reg, repo, _ := container.Current.ID.Components()
-			fmt.Fprintf(out, "%s\t%s\t%s/%s\t\n", sname, containerName, reg, repo)
+			if reg != "" {
+				reg += "/"
+			}
+			fmt.Fprintf(out, "%s\t%s\t%s%s\t\n", sname, containerName, reg, repo)
 			foundRunning := false
 			for _, available := range container.Available {
 				running := "|  "


### PR DESCRIPTION
Some service images are specified as `weaveworks/foo:12345` and they would get rendered as `/weaveworks/foo:12345`. Oops!
