### PR TITLE
Don't quote YAML strings

### DIFF
--- a/platform/kubernetes/update.go
+++ b/platform/kubernetes/update.go
@@ -102,20 +102,28 @@ func tryUpdate(def, newImageStr string, trace io.Writer, out io.Writer) error {
 	// * the name, with a re-tagged name
 	// * the image for the container
 	// * the version label (in two places)
+	//
+	// Some values (most likely the version) will be interpreted as a
+	// number if unquoted; while, on the other hand, it is apparently
+	// not OK to quote things that don't look like numbers. So: we
+	// extract values *without* quotes, and add them if necessary.
 
 	newDefName := oldDefName
 	if strings.HasSuffix(oldDefName, oldImage.Tag) {
 		newDefName = oldDefName[:len(oldDefName)-len(oldImage.Tag)] + newImage.Tag
 	}
 
+	newDefName = maybeQuote(newDefName)
+	newTag := maybeQuote(newImage.Tag)
+
 	fmt.Fprintln(trace, "")
 	fmt.Fprintln(trace, "Replacing ...")
-	fmt.Fprintf(trace, "Resource name: %q -> %q\n", oldDefName, newDefName)
-	fmt.Fprintf(trace, "Version in container %q (and selector if present): %q -> %q\n", containerName, oldImage.Tag, newImage.Tag)
-	fmt.Fprintf(trace, "Image for container %q: %q -> %q\n", containerName, oldImage, newImage)
+	fmt.Fprintf(trace, "Resource name: %s -> %s\n", oldDefName, newDefName)
+	fmt.Fprintf(trace, "Version in templates (and selector if present): %s -> %s\n", oldImage.Tag, newTag)
+	fmt.Fprintf(trace, "Image in templates: %s -> %s\n", oldImage, newImage)
 	fmt.Fprintln(trace, "")
 
-	// The name we want is that under metadata:, which will be indented once
+	// The name we want is that under `metadata:`, which will be indented once
 	replaceRCNameRE := regexp.MustCompile(`(?m:^(  name:\s*) (?:"?[\w-]+"?)(\s.*)$)`)
 	withNewDefName := replaceRCNameRE.ReplaceAllString(def, fmt.Sprintf(`$1 %s$2`, newDefName))
 
@@ -125,7 +133,7 @@ func tryUpdate(def, newImageStr string, trace io.Writer, out io.Writer) error {
 		`((?:  ){2,4}name:.*)`,
 		`((?:  ){2,4}version:\s*) (?:"?[-\w]+"?)(\s.*)`,
 	)
-	replaceLabels := fmt.Sprintf("$1\n$2\n$3 %s$4", newImage.Tag)
+	replaceLabels := fmt.Sprintf("$1\n$2\n$3 %s$4", newTag)
 	withNewLabels := replaceLabelsRE.ReplaceAllString(withNewDefName, replaceLabels)
 
 	replaceImageRE := multilineRE(
@@ -141,4 +149,18 @@ func tryUpdate(def, newImageStr string, trace io.Writer, out io.Writer) error {
 
 func multilineRE(lines ...string) *regexp.Regexp {
 	return regexp.MustCompile(`(?m:^` + strings.Join(lines, "\n") + `$)`)
+}
+
+var looksLikeNumber *regexp.Regexp = regexp.MustCompile("^(" + strings.Join([]string{
+	`(-?[1-9](\.[0-9]*[1-9])?(e[-+][1-9][0-9]*)?)`,
+	`(-?(0|[1-9][0-9]*))`,
+	`(0|(\.inf)|(-\.inf)|(\.nan))`},
+	"|") + ")$")
+
+func maybeQuote(scalar string) string {
+	fmt.Printf("Looks like number: %s = %v\n", scalar, looksLikeNumber.MatchString(scalar))
+	if looksLikeNumber.MatchString(scalar) {
+		return `"` + scalar + `"`
+	}
+	return scalar
 }

--- a/platform/kubernetes/update_test.go
+++ b/platform/kubernetes/update_test.go
@@ -14,6 +14,7 @@ func testUpdate(t *testing.T, caseIn, updatedImage, caseOut string) {
 		t.Error(err)
 	}
 	if string(out.Bytes()) != caseOut {
+		fmt.Fprintf(os.Stderr, "--- TRACE ---\n"+trace.String()+"\n---\n")
 		t.Errorf("Did not get expected result, instead got\n\n%s", string(out.Bytes()))
 	}
 }
@@ -22,11 +23,14 @@ func TestUpdates(t *testing.T) {
 	for _, c := range [][]string{
 		{case1, case1image, case1out},
 		{case2, case2image, case2out},
+		{case2out, case2reverseImage, case2},
 	} {
 		testUpdate(t, c[0], c[1], c[2])
 	}
 }
 
+// Unusual but still valid indentation between containers: and the
+// next line
 const case1 = `---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -107,6 +111,7 @@ spec:
                 path: pr-assigner.json
 `
 
+// Version looks like a number
 const case2 = `---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -147,7 +152,7 @@ spec:
         - --repo-path=testdata
 `
 
-const case2image = `weaveworks/fluxy:master-a000002`
+const case2image = `weaveworks/fluxy:1234567`
 
 const case2out = `---
 apiVersion: extensions/v1beta1
@@ -160,7 +165,7 @@ spec:
     metadata:
       labels:
         name: fluxy
-        version: master-a000002
+        version: "1234567"
     spec:
       volumes:
       - name: key
@@ -168,7 +173,7 @@ spec:
           secretName: fluxy-repo-key
       containers:
       - name: fluxy
-        image: weaveworks/fluxy:master-a000002
+        image: weaveworks/fluxy:1234567
         imagePullPolicy: Never # must build manually
         ports:
         - containerPort: 3030
@@ -188,3 +193,5 @@ spec:
         - --repo-key=/var/run/secrets/fluxy/key/id-rsa
         - --repo-path=testdata
 `
+
+const case2reverseImage = `weaveworks/fluxy:master-a000001`


### PR DESCRIPTION
Apparently quoting strings is bad, because some YAML parsers choke on quoted
strings. Not quoting them does have the problem that things that look
like numbers (like certain hex-encoded hashes) will be interpreted as
numbers, upsetting the decoder or application. In those cases, the
value is supposed to be quo-- .. wait a second..

Posted for comment.
