### PR TITLE
The latest image should not include "latest"

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,6 +4,7 @@ package registry
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -147,6 +148,19 @@ func (c *Client) tagsToRepository(client *dockerregistry.Registry, repoName stri
 type Repository struct {
 	Name   string // "quay.io:5000/weaveworks/helloworld"
 	Images []Image
+}
+
+// LatestImage returns the latest releasable image from the repository.
+// A releasable image is one that is not tagged "latest".
+// Images must be kept in newest-first order.
+func (r Repository) LatestImage() (Image, error) {
+	for _, image := range r.Images {
+		if strings.EqualFold(image.Tag, "latest") {
+			continue
+		}
+		return image, nil
+	}
+	return Image{}, errors.New("no valid images in repository")
 }
 
 // Image represents a specific container image available in a repository. It's a

--- a/release/release.go
+++ b/release/release.go
@@ -105,7 +105,11 @@ func (s *releaser) releaseAllToLatest(kind flux.ReleaseKind) (res []flux.Release
 			if err != nil {
 				return nil, errors.Wrapf(err, "fetching image repo for %s", currentImageID)
 			}
-			latestImageID := flux.ParseImageID(imageRepo.Images[0].String())
+			latestImage, err := imageRepo.LatestImage()
+			if err != nil {
+				return nil, errors.Wrapf(err, "getting latest image from %s", imageRepo.Name)
+			}
+			latestImageID := flux.ParseImageID(latestImage.String())
 			if currentImageID == latestImageID {
 				res = append(res, s.releaseActionNop(fmt.Sprintf("Service image %s is already the latest one; skipping.", currentImageID)))
 				continue
@@ -235,7 +239,11 @@ func (s *releaser) releaseOneToLatest(id flux.ServiceID, kind flux.ReleaseKind) 
 			continue
 		}
 
-		latestID := flux.ParseImageID(imageRepo.Images[0].String())
+		latestImage, err := imageRepo.LatestImage()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting latest image from %s", imageRepo.Name)
+		}
+		latestID := flux.ParseImageID(latestImage.String())
 		if imageID == latestID {
 			res = append(res, s.releaseActionNop(fmt.Sprintf("The service image %s is already at latest; skipping.", imageID)))
 		}


### PR DESCRIPTION
Add registry/Repository.LatestImage method. LatestImage returns the latest releasable image from the repository. A releasable image is one that is not tagged "latest".
