### PR TITLE
Add --namespace flag to list-services

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,8 +20,8 @@ func NewClient(c *http.Client, router *mux.Router, endpoint string) Service {
 	}
 }
 
-func (c *client) ListServices() ([]ServiceStatus, error) {
-	return invokeListServices(c.client, c.router, c.endpoint)
+func (c *client) ListServices(namespace string) ([]ServiceStatus, error) {
+	return invokeListServices(c.client, c.router, c.endpoint, namespace)
 }
 
 func (c *client) ListImages(s ServiceSpec) ([]ImageStatus, error) {

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -10,6 +10,7 @@ import (
 
 type serviceListOpts struct {
 	*serviceOpts
+	namespace string
 }
 
 func newServiceList(parent *serviceOpts) *serviceListOpts {
@@ -23,6 +24,7 @@ func (opts *serviceListOpts) Command() *cobra.Command {
 		Example: makeExample("fluxctl list-services"),
 		RunE:    opts.RunE,
 	}
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace to query, blank for all namespaces")
 	return cmd
 }
 
@@ -31,7 +33,7 @@ func (opts *serviceListOpts) RunE(_ *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	services, err := opts.Fluxd.ListServices()
+	services, err := opts.Fluxd.ListServices(opts.namespace)
 	if err != nil {
 		return err
 	}

--- a/helper.go
+++ b/helper.go
@@ -23,15 +23,25 @@ func (s *Helper) AllServices() ([]ServiceID, error) {
 
 	var res []ServiceID
 	for _, namespace := range namespaces {
-		services, err := s.Platform.Services(namespace)
+		ids, err := s.NamespaceServices(namespace)
 		if err != nil {
-			return nil, errors.Wrapf(err, "fetching platform services for namespace %q", namespace)
+			return nil, err
 		}
+		res = append(res, ids...)
+	}
 
-		for _, service := range services {
-			id := MakeServiceID(namespace, service.Name)
-			res = append(res, id)
-		}
+	return res, nil
+}
+
+func (s *Helper) NamespaceServices(namespace string) ([]ServiceID, error) {
+	services, err := s.Platform.Services(namespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching platform services for namespace %q", namespace)
+	}
+
+	res := make([]ServiceID, len(services))
+	for i, service := range services {
+		res[i] = MakeServiceID(namespace, service.Name)
 	}
 
 	return res, nil

--- a/service.go
+++ b/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Service interface {
-	ListServices() ([]ServiceStatus, error)
+	ListServices(namespace string) ([]ServiceStatus, error)
 	ListImages(ServiceSpec) ([]ImageStatus, error)
 	Release(ServiceSpec, ImageSpec, ReleaseKind) ([]ReleaseAction, error)
 	Automate(ServiceID) error


### PR DESCRIPTION
Adds an extra namespace parameter to ListServices methods, which may be blank to indicate all namespaces. I figured this was better than having two code paths, because "namespace" may have different or no meanings on different platforms.

@squaremo, this is just an optimization, no rush.
