### PR TITLE
Work around quay.io auth

### DIFF
--- a/registry/quay.go
+++ b/registry/quay.go
@@ -1,0 +1,62 @@
+package registry
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Workaround for quay.io, which fails to quote the scope value in its
+// WWW-Authenticate header. Annoying.  This also remembers a Bearer
+// token, so once you have authenticated, it can keep using it rather
+// than authenticating each time.
+
+type wwwAuthenticateFixer struct {
+	transport   http.RoundTripper
+	tokenHeader string
+}
+
+func (t *wwwAuthenticateFixer) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.maybeAddToken(req)
+	res, err := t.transport.RoundTrip(req)
+	if err == nil {
+		newAuthHeaders := []string{}
+		for _, h := range res.Header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+			if strings.HasPrefix(h, "Bearer ") {
+				h = replaceUnquoted(h)
+			}
+			newAuthHeaders = append(newAuthHeaders, h)
+		}
+		res.Header[http.CanonicalHeaderKey("WWW-Authenticate")] = newAuthHeaders
+	}
+	return res, err
+}
+
+var scopeRE *regexp.Regexp = regexp.MustCompile(`,scope=([^"].*[^"])$`)
+
+// This is pretty specific. quay.io leaves the `scope` parameter
+// unquoted, which trips up parsers (the one in the library we're
+// using, for example). So replace an unquoted value with a quoted
+// value, for that parameter.
+func replaceUnquoted(h string) string {
+	return scopeRE.ReplaceAllString(h, `,scope="$1"`)
+}
+
+// If we've got a token from a previous roundtrip, try using it
+// again. BEWARE: this means this transport should only be used when
+// asking (repeatedly) about a single repository, otherwise we may
+// leak authorisation.
+func (t *wwwAuthenticateFixer) maybeAddToken(req *http.Request) {
+	authHeaders := req.Header[http.CanonicalHeaderKey("Authorization")]
+	for _, h := range authHeaders {
+		if strings.EqualFold(h[:7], "bearer ") {
+			if t.tokenHeader == "" {
+				t.tokenHeader = h
+			}
+			return
+		}
+	}
+	if t.tokenHeader != "" {
+		req.Header.Set("Authorization", t.tokenHeader)
+	}
+}


### PR DESCRIPTION
quay.io does not quote the `scope` value in its WWW-Authenticate
header, causing the library we use
(github.com/heroku/docker-registry-client) for the v2 registry API to
fail to parse the header.

The library authenticates every single request by default, meaning
that every manifest lookup (to get the image created time) uses three
roundtrips.

To solve both of these, this commit introduces a transport wrapper that
1. rewrites the WWW-Authenticate header of responses if necessary;
2. remembers the authentication bearer token (once established) for
   subsequent requests.

This commit fixes a silly bug, too: the auth entries in a docker
config are keyed by the host name, not "https://" + the host name.
