### PR TITLE
git commands will now fail instead of prompting

### DIFF
--- a/docker/Dockerfile.fluxy
+++ b/docker/Dockerfile.fluxy
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 WORKDIR /home/flux
-RUN apk add --no-cache git openssh python py-yaml
+RUN apk add --no-cache git>=2.3.0 openssh python py-yaml
 ADD ./kubectl /home/flux/
 COPY ./ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY ./kubeservice /home/flux/

--- a/git/releasing.go
+++ b/git/releasing.go
@@ -6,10 +6,38 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+
+	"github.com/pkg/errors"
 )
 
-func cmd(dir, repoKey string, args ...string) *exec.Cmd {
+func clone(workingDir, repoKey, repoURL string) (path string, err error) {
+	repoPath := filepath.Join(workingDir, "repo")
+	if err := gitCmd("", repoKey, "clone", repoURL, repoPath).Run(); err != nil {
+		return "", errors.Wrap(err, "git clone")
+	}
+	return repoPath, nil
+}
+
+func commit(workingDir, commitMessage string) error {
+	if err := gitCmd(
+		workingDir, "",
+		"-c", "user.name=Weave Flux", "-c", "user.email=support@weave.works",
+		"commit",
+		"--no-verify", "-a", "-m", commitMessage,
+	).Run(); err != nil {
+		return errors.Wrap(err, "git commit")
+	}
+	return nil
+}
+
+func push(repoKey, workingDir string) error {
+	if err := gitCmd(workingDir, repoKey, "push", "origin", "master").Run(); err != nil {
+		return errors.Wrap(err, "git push origin master")
+	}
+	return nil
+}
+
+func gitCmd(dir, repoKey string, args ...string) *exec.Cmd {
 	c := exec.Command("git", args...)
 	if dir != "" {
 		c.Dir = dir
@@ -25,44 +53,14 @@ func env(repoKey string) []string {
 	if repoKey == "" {
 		return []string{base}
 	}
-	return []string{fmt.Sprintf("%s -i %q", base, repoKey)}
+	return []string{fmt.Sprintf("%s -i %q", base, repoKey), "GIT_TERMINAL_PROMPT=0"}
 }
 
-func clone(workingDir, repoKey, repoURL string) (path string, err error) {
-	repoPath := filepath.Join(workingDir, "repo")
-	if err := cmd("", repoKey, "clone", repoURL, repoPath).Run(); err != nil {
-		return "", fmt.Errorf("git clone: %v", err)
-	}
-	return repoPath, nil
-}
-
-// check for changes
+// check returns true if there are changes locally.
 func check(workingDir, subdir string) bool {
-	diff := cmd(workingDir, "", "diff", "--quiet", "--", subdir)
+	diff := gitCmd(workingDir, "", "diff", "--quiet", "--", subdir)
 	// `--quiet` means "exit with 1 if there are changes"
 	return diff.Run() != nil
-}
-
-func commit(workingDir, commitMessage string) error {
-	for _, c := range [][]string{
-		{"-c", "user.name=Weave Flux", "-c", "user.email=support@weave.works", "commit", "--no-verify", "-a", "-m", commitMessage},
-	} {
-		if err := cmd(workingDir, "", c...).Run(); err != nil {
-			return fmt.Errorf("%s: %v", strings.Join(c, " "), err)
-		}
-	}
-	return nil
-}
-
-func push(repoKey, workingDir string) error {
-	for _, c := range [][]string{
-		{"push", "origin", "master"},
-	} {
-		if err := cmd(workingDir, repoKey, c...).Run(); err != nil {
-			return fmt.Errorf("%s: %v", strings.Join(c, " "), err)
-		}
-	}
-	return nil
 }
 
 func copyKey(working, key string) (string, error) {


### PR DESCRIPTION
Requires git 2.3.0+, thus the Dockerfile change. Although that's more for safety than necessity. For proof:

```
$ docker run -t -i weaveworks/fluxy git --version
git version 2.6.6
```

Fixes #119.
