### PR TITLE
Bump API version /v1 to /v2

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -20,13 +20,13 @@ import (
 
 func NewRouter() *mux.Router {
 	r := mux.NewRouter()
-	r.NewRoute().Name("ListServices").Methods("GET").Path("/v1/services").Queries("namespace", "{namespace}") // optional namespace!
-	r.NewRoute().Name("ListImages").Methods("GET").Path("/v1/images").Queries("service", "{service}")
-	r.NewRoute().Name("PostRelease").Methods("POST").Path("/v1/release").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
-	r.NewRoute().Name("GetRelease").Methods("GET").Path("/v1/release").Queries("id", "{id}")
-	r.NewRoute().Name("Automate").Methods("POST").Path("/v1/automate").Queries("service", "{service}")
-	r.NewRoute().Name("Deautomate").Methods("POST").Path("/v1/deautomate").Queries("service", "{service}")
-	r.NewRoute().Name("History").Methods("GET").Path("/v1/history").Queries("service", "{service}")
+	r.NewRoute().Name("ListServices").Methods("GET").Path("/v2/services").Queries("namespace", "{namespace}") // optional namespace!
+	r.NewRoute().Name("ListImages").Methods("GET").Path("/v2/images").Queries("service", "{service}")
+	r.NewRoute().Name("PostRelease").Methods("POST").Path("/v2/release").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
+	r.NewRoute().Name("GetRelease").Methods("GET").Path("/v2/release").Queries("id", "{id}")
+	r.NewRoute().Name("Automate").Methods("POST").Path("/v2/automate").Queries("service", "{service}")
+	r.NewRoute().Name("Deautomate").Methods("POST").Path("/v2/deautomate").Queries("service", "{service}")
+	r.NewRoute().Name("History").Methods("GET").Path("/v2/history").Queries("service", "{service}")
 	return r
 }
 


### PR DESCRIPTION
This should have happened in #157 because the semantics of POST /release changed. Thanks to @squaremo for the spot. Works On My Machine™
