### PR TITLE
Sort results of list-* commands

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/fluxy"
 )
 
 type serviceShowOpts struct {
@@ -43,6 +46,8 @@ func (opts *serviceShowOpts) RunE(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	sort.Sort(imageStatusByName(services))
 
 	out := newTabwriter()
 
@@ -93,4 +98,18 @@ func (opts *serviceShowOpts) RunE(_ *cobra.Command, args []string) error {
 	}
 	out.Flush()
 	return nil
+}
+
+type imageStatusByName []flux.ImageStatus
+
+func (s imageStatusByName) Len() int {
+	return len(s)
+}
+
+func (s imageStatusByName) Less(a, b int) bool {
+	return s[a].ID < s[b].ID
+}
+
+func (s imageStatusByName) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
 }

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -38,6 +39,8 @@ func (opts *serviceListOpts) RunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	sort.Sort(serviceStatusByName(services))
+
 	w := newTabwriter()
 	fmt.Fprintf(w, "SERVICE\tCONTAINER\tIMAGE\tRELEASE\tAUTOMATION\n")
 	for _, s := range services {
@@ -60,4 +63,18 @@ func maybeAutomated(s flux.ServiceStatus) string {
 		return "automated"
 	}
 	return ""
+}
+
+type serviceStatusByName []flux.ServiceStatus
+
+func (s serviceStatusByName) Len() int {
+	return len(s)
+}
+
+func (s serviceStatusByName) Less(a, b int) bool {
+	return s[a].ID < s[b].ID
+}
+
+func (s serviceStatusByName) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
 }


### PR DESCRIPTION
When looking at a system with lots of services in different namespaces, it's quite a jumble. This makes the output stable and easier to read.
