### PR TITLE
Provide --namespace when checking rollout status

### DIFF
--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -108,6 +108,7 @@ func deploymentExec(def *apiext.Deployment, newDef *apiObject) regradeExecFunc {
 			cmd := c.kubectlCommand(
 				"rollout", "status",
 				"deployment", newDef.Metadata.Name,
+				"--namespace", newDef.Metadata.Namespace,
 			)
 			logger.Log("cmd", strings.Join(cmd.Args, " "))
 			err = cmd.Run()


### PR DESCRIPTION
In the latest edition of "How Did This Ever Work" I just now tried to release a small deployment-based service in a non-default namespace on our dev cluster. I never got a Slack notification, but the service was successfully regraded. I dug into the logs and found (abridged)

```
  kubectl [...] apply -f -
  deployment "pr-assigner" configured
  kubectl [...] rollout status deployment pr-assigner
  Error from server: deployments.extensions "pr-assigner" not found
```

I reproduced this behavior manually, but got it to work by providing an explicit --namespace=extra flag to kubectl. So this does what I did. As far as I can tell, services based on deployments in non-default namespaces have never been successfully releasable. Maybe we just got lucky so far.
