### PR TITLE
Make Slack notifications work again

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -230,7 +230,7 @@ func main() {
 				http.DefaultClient,
 				*slackWebhookURL,
 				*slackUsername,
-				`Release`, // only catch the final message
+				`Regrade`, // only catch the final message
 			))
 			logger.Log("Slack", "enabled", "username", *slackUsername)
 		} else {


### PR DESCRIPTION
Slack notifications work by tapping in to the history for a given service, and use a set of regexps to determine which history entries to forward to the Slack channel. In a recent change, we changed "Release" to "Regrade", but did not update the regexp to catch it.

Note the difference:

```
TIME                 TYPE  MESSAGE
23 Sep 16 14:24 UTC  v0    users: Regrade quay.io/weaveworks/users...
23 Sep 16 14:24 UTC  v0    users: Starting regrade quay.io/weaveworks/users...
23 Sep 16 12:53 UTC  v0    users: Release quay.io/weaveworks/users...
23 Sep 16 12:53 UTC  v0    users: Starting release quay.io/weaveworks/users...
```
