### PR TITLE
Remove namespace arg from history.AllEvents

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -24,10 +24,12 @@ type EventWriter interface {
 }
 
 type EventReader interface {
-	// AllEvents returns a history for every service in the given namespace.
-	AllEvents(namespace string) ([]Event, error)
+	// AllEvents returns a history for every service. Events must be
+	// returned in descending timestamp order.
+	AllEvents() ([]Event, error)
 
-	// EventsForService returns the history for a particular service.
+	// EventsForService returns the history for a particular
+	// service. Events must be returned in descending timestamp order.
 	EventsForService(namespace, service string) ([]Event, error)
 }
 

--- a/history/sql/sql.go
+++ b/history/sql/sql.go
@@ -71,11 +71,10 @@ func (db *DB) queryEvents(query string, params ...interface{}) ([]history.Event,
 	return events, nil
 }
 
-func (db *DB) AllEvents(namespace string) ([]history.Event, error) {
+func (db *DB) AllEvents() ([]history.Event, error) {
 	return db.queryEvents(`SELECT service, message, stamp
                            FROM history
-                           WHERE namespace = $1
-                           ORDER BY service, stamp DESC`, namespace)
+                           ORDER BY stamp DESC`)
 }
 
 func (db *DB) EventsForService(namespace, service string) ([]history.Event, error) {

--- a/server.go
+++ b/server.go
@@ -182,18 +182,9 @@ func (s *server) History(spec ServiceSpec) (res []HistoryEntry, err error) {
 
 	var events []history.Event
 	if spec == ServiceSpecAll {
-		namespaces, err := s.helper.PlatformNamespaces()
+		events, err = s.history.AllEvents()
 		if err != nil {
-			return nil, errors.Wrap(err, "fetching platform namespaces")
-		}
-
-		for _, namespace := range namespaces {
-			ev, err := s.history.AllEvents(namespace)
-			if err != nil {
-				return nil, errors.Wrapf(err, "fetching all history events for namespace %s", namespace)
-			}
-
-			events = append(events, ev...)
+			return nil, errors.Wrap(err, "fetching all history events")
 		}
 	} else {
 		id, err := ParseServiceID(string(spec))
@@ -202,12 +193,10 @@ func (s *server) History(spec ServiceSpec) (res []HistoryEntry, err error) {
 		}
 
 		namespace, service := id.Components()
-		ev, err := s.history.EventsForService(namespace, service)
+		events, err = s.history.EventsForService(namespace, service)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching history events for %s", id)
 		}
-
-		events = append(events, ev...)
 	}
 
 	res = make([]HistoryEntry, len(events))


### PR DESCRIPTION
This was unnecessary, since it's not asked for events by namespace by
the client.

It also led to events being out of order, since they were requested
per namespace first then combined.
