### PR TITLE
Make release progress in terminal "live"

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -287,6 +287,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/gosuri/uilive",
+			"repository": "https://github.com/gosuri/uilive",
+			"vcs": "git",
+			"revision": "efb88ccd059957c48f24f9d351d33a0eb00ede41",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/hashicorp/go-cleanhttp",
 			"repository": "https://github.com/hashicorp/go-cleanhttp",
 			"vcs": "git",
@@ -374,6 +382,14 @@
 			"repository": "https://github.com/magiconair/properties",
 			"vcs": "git",
 			"revision": "b3f6dd549956e8a61ea4a686a1c02a33d5bdda4b",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/mattn/go-isatty",
+			"repository": "https://github.com/mattn/go-isatty",
+			"vcs": "git",
+			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
The progress output in a terminal repeats itself, and is unimportant
once the result is available. This commit makes that output clear
itself, keeping to one line while reporting progress.

NB requires a `gvt restore`.
