### PR TITLE
Add Slack username to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,7 +12,8 @@ type GitConfig struct {
 }
 
 type SlackConfig struct {
-	HookURL string `json:"hookURL" yaml:"hookURL"`
+	HookURL  string `json:"hookURL" yaml:"hookURL"`
+	Username string `json:"username" yaml:"username"`
 }
 
 type RegistryConfig struct {


### PR DESCRIPTION
Add the Slack username, which was missing from config, so that people can upload a complete config in the interim before `MultitenantInstancer` is deployed.
