### PR TITLE
Update deploy/ for multitenant fluxy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,23 +7,23 @@ If you're using [minikube](https://github.com/kubernetes/minikube) to try things
 
 ```
 eval $(minikube docker-env)
-make clean build
+make clean all
 ```
 
-which will build the image in minikube's Docker daemon,
- thus making it available to Kubernetes.
+which will build the image in minikube's Docker daemon, thus making it
+available to Kubernetes.
 
 ## Creating a key for automation
 
-The automation component mutates a Git repository containing your
-Kubernetes config, which requires an SSH access key.  That private key
-is stored as a Kubernetes secret named `fluxy-repo-key`.
+Fluxy updates a Git repository containing your Kubernetes config each
+time a service is released; this will usually require an SSH access
+key.
 
 Here is an example of setting this up for the `helloworld` example in
 the fluxy repository.
 
 Fork the fluxy repository on github (you may also wish to rename it,
-e.g., to `fluxy-testconf`). Now, we're going to add a deploy key so
+e.g., to `fluxy-testdata`). Now, we're going to add a deploy key so
 fluxy can push to that repo. Generate a key in the console:
 
 ```
@@ -35,33 +35,13 @@ Fluxy in a minute, and a public key file (`id-rsa-fluxy.pub`) which
 we'll now give to Github.
 
 On the Github page for your forked repo, go to the settings and find
-the "Deploy keys" page. Add one, and paste in the contents of the
-`id-rsa-fluxy.pub` file -- the public key.
-
-Kubernetes wants the private key in the form of a secret. To create that,
-
-```
-kubectl delete secret fluxy-repo-key
-kubectl create secret generic fluxy-repo-key --from-file=id-rsa=id-rsa-fluxy
-```
+the "Deploy keys" page. Add one, check the write access box, and paste
+in the contents of the `id-rsa-fluxy.pub` file -- the public key.
 
 ## Customising the deployment config
 
 The file `fluxy-deployment.yaml` contains a Kubernetes deployment
 configuration that runs the latest image of Fluxy.
-
-You will need to change at least the repository arguments, to use your
-Github repo. Adapt these lines:
-
-```
-        - --repo-url=git@github.com:squaremo/fluxy-testdata
-        - --repo-key=/var/run/secrets/fluxy/key/id-rsa
-        - --repo-path=testdata
-```
-
-The last, `--repo-path`, refers to the directory _within_ the
-repository containing the configuration files (the setting above is
-correct if you have forked the fluxy repo as described so far).
 
 You can create the deployment now:
 
@@ -69,7 +49,8 @@ You can create the deployment now:
 kubectl create -f fluxy-deployment.yaml
 ```
 
-To make the pod accessible to `fluxctl`, you can create a service for Fluxy and use the Kubernetes API proxy to access it:
+To make the pod accessible to `fluxctl`, you can create a service for
+Fluxy and use the Kubernetes API proxy to access it:
 
 ```
 kubectl create -f fluxy-service.yaml
@@ -77,11 +58,89 @@ kubectl proxy &
 export FLUX_URL=http://localhost:8001/api/v1/proxy/namespaces/default/services/fluxy
 ```
 
-This will work with the default settings of `fluxctl`,
- and is especially handy with minikube.
+This will work with the default settings of `fluxctl`, and is
+especially handy with minikube.
+
+At this point you can see if it's all running by doing:
+
+```
+fluxctl list-services
+```
 
 To force Kubernetes to run the latest image after a rebuild, kill the pod:
 
 ```
 kubectl get pods | grep fluxy | awk '{ print $1 }' | xargs kubectl delete pod
+```
+
+## Uploading a configuration
+
+To begin using Fluxy, you need to provide at least the git repository
+and the key from earlier.
+
+Get a blank config with
+
+```sh
+fluxctl get-config > fluxy.conf
+```
+
+Now edit the file `fluxy.conf` -- it'll look like this:
+
+```yaml
+git:
+  URL: ""
+  path: ""
+  branch: ""
+  key: ""
+slack:
+  hookURL: ""
+  username: ""
+registry:
+  auths: {}
+```
+
+Here's an example with values filled in:
+
+```yaml
+git:
+  URL: git@github.com:squaremo/fluxy-testdata
+  path: testdata
+  branch: master
+  key: |
+         -----BEGIN RSA PRIVATE KEY-----
+         ZNsnTooXXGagxg5a3vqsGPgoHH1KvqE5my+v7uYhRxbHi5uaTNEWnD46ci06PyBz
+         zSS6I+zgkdsQk7Pj2DNNzBS6n08gl8OJX073JgKPqlfqDSxmZ37XWdGMlkeIuS21
+         nwli0jsXVMKO7LYl+b5a0N5ia9cqUDEut1eeKN+hwDbZeYdT/oGBsNFgBRTvgQhK
+         ... contents of id-rsa-fluxy file from above ...
+         -----END RSA PRIVATE KEY-----
+slack:
+  hookURL: ""
+  username: ""
+registry:
+  auths: {}
+```
+
+Note the use of `|` to have a multiline string value for the key; all
+the lines must be indented if you use that.
+
+If you use any private Docker image repositories, you will also need
+to supply authentication information for those. These are given per
+registry, like the following snippet (you can nick these from the
+analagous section of ~/.docker/config.json, they are just
+base64-encoded `<username>:<password>`):
+
+```yaml
+# ...
+registry:
+  auths:
+    'https://index.docker.io/v1/':
+      auth: "dXNlcm5hbWU6cGFzc3dvcmQK"
+```
+
+(NB the key is a URL, and will usually have to be quoted as it is above.)
+
+Finally, give the config to Fluxy:
+
+```sh
+fluxctl set-config --file=fluxy.conf
 ```

--- a/deploy/fluxy-deployment.yaml
+++ b/deploy/fluxy-deployment.yaml
@@ -9,27 +9,16 @@ spec:
       labels:
         name: fluxy
     spec:
-      volumes:
-      - name: key
-        secret:
-          secretName: fluxy-repo-key
       containers:
       - name: fluxy
         image: weaveworks/fluxy
         imagePullPolicy: Never # must build manually
         ports:
         - containerPort: 3030
-        volumeMounts:
-        - name: key
-          mountPath: /var/run/secrets/fluxy/key
-          readOnly: true
         args:
         - /home/flux/fluxd
         - --kubernetes-kubectl=/home/flux/kubectl
         - --kubernetes-host=https://kubernetes
         - --kubernetes-certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - --kubernetes-bearer-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-        - --database-source=ql:history.db
-        - --repo-url=git@github.com:squaremo/fluxy-testdata
-        - --repo-key=/var/run/secrets/fluxy/key/id-rsa
-        - --repo-path=testdata
+        - --database-source=file://fluxy.db


### PR DESCRIPTION
Most of the things supplied in command-line arguments are now given as
a config file per instance, so remove them from the deployment yamel,
and explain them in the README.
