### PR TITLE
Refactor update and release packages to break some dependencies

### DIFF
--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -13,16 +13,16 @@ import (
 	"github.com/weaveworks/flux/policy"
 )
 
-func (m *Manifests) UpdatePolicies(in []byte, update policy.Update) ([]byte, error) {
-	tagAll, _ := update.Add.Get(policy.TagAll)
+func (m *Manifests) UpdatePolicies(in []byte, add policy.Set, remove policy.Set) ([]byte, error) {
+	tagAll, _ := add.Get(policy.TagAll)
 	return updateAnnotations(in, tagAll, func(a map[string]string) map[string]string {
-		for p, v := range update.Add {
+		for p, v := range add {
 			if p == policy.TagAll {
 				continue
 			}
 			a[resource.PolicyPrefix+string(p)] = v
 		}
-		for p, _ := range update.Remove {
+		for p, _ := range remove {
 			delete(a, resource.PolicyPrefix+string(p))
 		}
 		return a

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/weaveworks/flux/image"
 )
 
-type update struct {
+type testCase struct {
 	name            string
 	containers      []string
 	updatedImage    string
 	caseIn, caseOut string
 }
 
-func testUpdate(t *testing.T, u update) {
+func testUpdate(t *testing.T, u testCase) {
 	id, err := image.ParseRef(u.updatedImage)
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +39,7 @@ func testUpdate(t *testing.T, u update) {
 }
 
 func TestUpdates(t *testing.T) {
-	for _, c := range []update{
+	for _, c := range []testCase{
 		{"common case", case1container, case1image, case1, case1out},
 		{"new version like number", case2container, case2image, case2, case2out},
 		{"old version like number", case2container, case2reverseImage, case2out, case2},

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -28,7 +28,7 @@ type Manifests interface {
 	// Parse the manifests given in an exported blob
 	ParseManifests([]byte) (map[string]resource.Resource, error)
 	// UpdatePolicies modifies a manifest to apply the policy update specified
-	UpdatePolicies([]byte, policy.Update) ([]byte, error)
+	UpdatePolicies(def []byte, add policy.Set, remove policy.Set) ([]byte, error)
 	// ServicesWithPolicies returns all services with their associated policies
 	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -21,7 +21,7 @@ type Mock struct {
 	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
-	UpdatePoliciesFunc       func([]byte, policy.Update) ([]byte, error)
+	UpdatePoliciesFunc       func([]byte, policy.Set, policy.Set) ([]byte, error)
 	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
 }
 
@@ -69,8 +69,8 @@ func (m *Mock) UpdateManifest(path string, resourceID string, f func(def []byte)
 	return m.UpdateManifestFunc(path, resourceID, f)
 }
 
-func (m *Mock) UpdatePolicies(def []byte, p policy.Update) ([]byte, error) {
-	return m.UpdatePoliciesFunc(def, p)
+func (m *Mock) UpdatePolicies(def []byte, add policy.Set, remove policy.Set) ([]byte, error) {
+	return m.UpdatePoliciesFunc(def, add, remove)
 }
 
 func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -103,11 +103,10 @@ func (opts *controllerPolicyOpts) RunE(cmd *cobra.Command, args []string) error 
 	}
 
 	ctx := context.Background()
-	updates := policy.Updates{
-		resourceID: changes,
-	}
+	updates := update.Policy{}
+	updates[resourceID] = changes
 	jobID, err := opts.API.UpdateManifests(ctx, update.Spec{
-		Type:  update.Policy,
+		Type:  update.SpecPolicy,
 		Cause: opts.cause,
 		Spec:  updates,
 	})
@@ -117,7 +116,7 @@ func (opts *controllerPolicyOpts) RunE(cmd *cobra.Command, args []string) error 
 	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbosity)
 }
 
-func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {
+func calculatePolicyChanges(opts *controllerPolicyOpts) (update.PolicyChange, error) {
 	add := policy.Set{}
 	if opts.automate {
 		add = add.Add(policy.Automated)
@@ -148,7 +147,7 @@ func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {
 	for _, tagPair := range opts.tags {
 		parts := strings.Split(tagPair, "=")
 		if len(parts) != 2 {
-			return policy.Update{}, fmt.Errorf("invalid container/tag pair: %q. Expected format is 'container=filter'", tagPair)
+			return update.PolicyChange{}, fmt.Errorf("invalid container/tag pair: %q. Expected format is 'container=filter'", tagPair)
 		}
 
 		container, tag := parts[0], parts[1]
@@ -159,7 +158,7 @@ func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {
 		}
 	}
 
-	return policy.Update{
+	return update.PolicyChange{
 		Add:    add,
 		Remove: remove,
 	}, nil

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -131,7 +131,7 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		Excludes:     excludes,
 	}
 	jobID, err := opts.API.UpdateManifests(ctx, update.Spec{
-		Type:  update.Images,
+		Type:  update.SpecImages,
 		Cause: opts.cause,
 		Spec:  spec,
 	})

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -563,7 +563,7 @@ func imageIDs(status []v6.ImageStatus) []image.Info {
 
 func updateImage(ctx context.Context, d *Daemon, t *testing.T) job.ID {
 	return updateManifest(ctx, t, d, update.Spec{
-		Type: update.Images,
+		Type: update.SpecImages,
 		Spec: update.ReleaseSpec{
 			Kind:         update.ReleaseKindExecute,
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
@@ -574,8 +574,8 @@ func updateImage(ctx context.Context, d *Daemon, t *testing.T) job.ID {
 
 func updatePolicy(ctx context.Context, t *testing.T, d *Daemon) job.ID {
 	return updateManifest(ctx, t, d, update.Spec{
-		Type: update.Policy,
-		Spec: policy.Updates{
+		Type: update.SpecPolicy,
+		Spec: update.Policy{
 			flux.MustParseResourceID("default:deployment/helloworld"): {
 				Add: policy.Set{
 					policy.Locked: "true",

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -65,7 +65,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	}
 
 	if len(changes.Changes) > 0 {
-		d.UpdateManifests(ctx, update.Spec{Type: update.Auto, Spec: changes})
+		d.UpdateManifests(ctx, update.Spec{Type: update.SpecAuto, Spec: changes})
 	}
 }
 

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -307,7 +307,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 
 			// Interpret some notes as events to send to the upstream
 			switch n.Spec.Type {
-			case update.Images:
+			case update.SpecImages:
 				spec := n.Spec.Spec.(update.ReleaseSpec)
 				noteEvents = append(noteEvents, event.Event{
 					ServiceIDs: serviceIDs.ToSlice(),
@@ -326,7 +326,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 					},
 				})
 				includes[event.EventRelease] = true
-			case update.Auto:
+			case update.SpecAuto:
 				spec := n.Spec.Spec.(update.Automated)
 				noteEvents = append(noteEvents, event.Event{
 					ServiceIDs: serviceIDs.ToSlice(),
@@ -344,7 +344,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 					},
 				})
 				includes[event.EventAutoRelease] = true
-			case update.Policy:
+			case update.SpecPolicy:
 				// Use this to mean any change to policy
 				includes[event.EventUpdatePolicy] = true
 			default:

--- a/event/event.go
+++ b/event/event.go
@@ -15,14 +15,13 @@ import (
 
 // These are all the types of events.
 const (
-	EventCommit       = "commit"
-	EventSync         = "sync"
-	EventRelease      = "release"
-	EventAutoRelease  = "autorelease"
-	EventAutomate     = "automate"
-	EventDeautomate   = "deautomate"
-	EventLock         = "lock"
-	EventUnlock       = "unlock"
+	EventCommit      = "commit"
+	EventSync        = "sync"
+	EventRelease     = "release"
+	EventAutoRelease = "autorelease"
+	// This is not used as a Type of event, but _is_ used in Sync
+	// events to indicate that the commits just synced included
+	// changing policy.
 	EventUpdatePolicy = "update_policy"
 
 	// This is used to label e.g., commits that we _don't_ consider an event in themselves.
@@ -153,16 +152,6 @@ func (e Event) String() string {
 			svcStr = strings.Join(strServiceIDs, ", ")
 		}
 		return fmt.Sprintf("Sync: %s, %s", revStr, svcStr)
-	case EventAutomate:
-		return fmt.Sprintf("Automated: %s", strings.Join(strServiceIDs, ", "))
-	case EventDeautomate:
-		return fmt.Sprintf("Deautomated: %s", strings.Join(strServiceIDs, ", "))
-	case EventLock:
-		return fmt.Sprintf("Locked: %s", strings.Join(strServiceIDs, ", "))
-	case EventUnlock:
-		return fmt.Sprintf("Unlocked: %s", strings.Join(strServiceIDs, ", "))
-	case EventUpdatePolicy:
-		return fmt.Sprintf("Updated policies: %s", strings.Join(strServiceIDs, ", "))
 	default:
 		return fmt.Sprintf("Unknown event: %s", e.Type)
 	}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -46,7 +46,7 @@ func TestEvent_ParseReleaseMetaData(t *testing.T) {
 
 func TestEvent_ParseNoMetadata(t *testing.T) {
 	origEvent := Event{
-		Type: EventLock,
+		Type: EventUpdatePolicy,
 	}
 
 	bytes, _ := json.Marshal(origEvent)

--- a/flux.go
+++ b/flux.go
@@ -145,6 +145,12 @@ func (id *ResourceID) UnmarshalText(text []byte) error {
 
 type ResourceIDSet map[ResourceID]struct{}
 
+func ResourceIDSetOf(ids ...ResourceID) ResourceIDSet {
+	s := ResourceIDSet{}
+	s.Add(ids)
+	return s
+}
+
 func (s ResourceIDSet) String() string {
 	var ids []string
 	for id := range s {
@@ -157,6 +163,20 @@ func (s ResourceIDSet) Add(ids []ResourceID) {
 	for _, id := range ids {
 		s[id] = struct{}{}
 	}
+}
+
+func (s ResourceIDSet) With(others ResourceIDSet) ResourceIDSet {
+	if len(others) == 0 {
+		return s
+	}
+	newSet := ResourceIDSet{}
+	for id := range s {
+		newSet[id] = struct{}{}
+	}
+	for id := range others {
+		newSet[id] = struct{}{}
+	}
+	return newSet
 }
 
 func (s ResourceIDSet) Without(others ResourceIDSet) ResourceIDSet {
@@ -201,6 +221,16 @@ func (s ResourceIDSet) ToSlice() ResourceIDs {
 	keys := make(ResourceIDs, len(s))
 	for k := range s {
 		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func (s ResourceIDSet) ToStringSlice() []string {
+	i := 0
+	keys := make([]string, len(s))
+	for k := range s {
+		keys[i] = k.String()
 		i++
 	}
 	return keys

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -14,7 +14,6 @@ import (
 	transport "github.com/weaveworks/flux/http"
 	"github.com/weaveworks/flux/job"
 	fluxmetrics "github.com/weaveworks/flux/metrics"
-	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -205,7 +204,7 @@ func (s HTTPServer) UpdateImages(w http.ResponseWriter, r *http.Request) {
 		User:    r.FormValue("user"),
 		Message: r.FormValue("message"),
 	}
-	result, err := s.server.UpdateManifests(r.Context(), update.Spec{Type: update.Images, Cause: cause, Spec: spec})
+	result, err := s.server.UpdateManifests(r.Context(), update.Spec{Type: update.SpecImages, Cause: cause, Spec: spec})
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -214,7 +213,7 @@ func (s HTTPServer) UpdateImages(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s HTTPServer) UpdatePolicies(w http.ResponseWriter, r *http.Request) {
-	var updates policy.Updates
+	var updates update.Policy
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		transport.WriteError(w, r, http.StatusBadRequest, err)
 		return
@@ -225,7 +224,7 @@ func (s HTTPServer) UpdatePolicies(w http.ResponseWriter, r *http.Request) {
 		Message: r.FormValue("message"),
 	}
 
-	jobID, err := s.server.UpdateManifests(r.Context(), update.Spec{Type: update.Policy, Cause: cause, Spec: updates})
+	jobID, err := s.server.UpdateManifests(r.Context(), update.Spec{Type: update.SpecPolicy, Cause: cause, Spec: updates})
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -36,13 +36,6 @@ func Tag(policy Policy) bool {
 	return strings.HasPrefix(string(policy), "tag.")
 }
 
-type Updates map[flux.ResourceID]Update
-
-type Update struct {
-	Add    Set `json:"add"`
-	Remove Set `json:"remove"`
-}
-
 type Set map[Policy]string
 
 // We used to specify a set of policies as []Policy, and in some places

--- a/release/policy.go
+++ b/release/policy.go
@@ -1,0 +1,47 @@
+package release
+
+import (
+	"github.com/go-kit/kit/log"
+
+	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/update"
+)
+
+func ApplyPolicy(rc *ReleaseContext, p update.Policy, log log.Logger) (update.Result, error) {
+	result := update.Result{}
+	for serviceID, u := range p {
+		err := cluster.UpdateManifest(rc.Manifests(), rc.repo.ManifestDir(), serviceID, func(def []byte) ([]byte, error) {
+			newDef, err := rc.Manifests().UpdatePolicies(def, u.Add, u.Remove)
+			if err != nil {
+				result[serviceID] = update.ControllerResult{
+					Status: update.ReleaseStatusFailed,
+					Error:  err.Error(),
+				}
+				return nil, err
+			}
+			if string(newDef) == string(def) {
+				result[serviceID] = update.ControllerResult{
+					Status: update.ReleaseStatusSkipped,
+				}
+			} else {
+				result[serviceID] = update.ControllerResult{
+					Status: update.ReleaseStatusSuccess,
+				}
+			}
+			return newDef, nil
+		})
+		switch err {
+		case cluster.ErrNoResourceFilesFoundForService, cluster.ErrMultipleResourceFilesFoundForService:
+			result[serviceID] = update.ControllerResult{
+				Status: update.ReleaseStatusFailed,
+				Error:  err.Error(),
+			}
+		case nil:
+			// continue
+		default:
+			return result, err
+		}
+	}
+
+	return result, nil
+}

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -149,7 +149,7 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.Upst
 	}
 
 	updateSpec := update.Spec{
-		Type: update.Images,
+		Type: update.SpecImages,
 		Spec: update.ReleaseSpec{
 			ServiceSpecs: []update.ResourceSpec{
 				update.ResourceSpecAll,

--- a/remote/rpc/compat.go
+++ b/remote/rpc/compat.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"fmt"
 
-	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -23,7 +22,7 @@ func requireServiceSpecKinds(ss update.ResourceSpec, kinds []string) error {
 
 func requireSpecKinds(s update.Spec, kinds []string) error {
 	switch s := s.Spec.(type) {
-	case policy.Updates:
+	case update.Policy:
 		for id, _ := range s {
 			_, kind, _ := id.Components()
 			if !contains(kinds, kind) {

--- a/update/policy.go
+++ b/update/policy.go
@@ -1,0 +1,78 @@
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/policy"
+)
+
+type Policy map[flux.ResourceID]PolicyChange
+
+type PolicyChange struct {
+	Add    policy.Set `json:"add"`
+	Remove policy.Set `json:"remove"`
+}
+
+const (
+	LabelAutomated     = "Automated"
+	LabelDeautomated   = "Deautomated"
+	LabelLocked        = "Locked"
+	LabelUnlocked      = "Unlocked"
+	LabelUpdatedPolicy = "Updated policy" // catch-all
+)
+
+func (p Policy) CommitMessage(cause Cause) string {
+	summary := summarisePolicy(p)
+	commitMsg := &bytes.Buffer{}
+	prefix := "- "
+	switch {
+	case cause.Message != "":
+		fmt.Fprintf(commitMsg, "%s\n\n", cause.Message)
+	case len(summary) > 1:
+		fmt.Fprintf(commitMsg, "Updated policies\n\n")
+	default:
+		prefix = ""
+	}
+
+	for label, ids := range summary {
+		fmt.Fprintf(commitMsg, "%s%s: %s\n", prefix, label, strings.Join(ids.ToStringSlice(), ", "))
+	}
+	return commitMsg.String()
+}
+
+// summarisePolicy builds a map of type->serviceID, for the updates
+// given.
+func summarisePolicy(updates Policy) map[string]flux.ResourceIDSet {
+	byType := map[string]flux.ResourceIDSet{}
+	addID := func(t string, id flux.ResourceID) {
+		s := flux.ResourceIDSetOf(id)
+		byType[t] = s.With(byType[t])
+	}
+
+	for serviceID, u := range updates {
+		for p, _ := range u.Add {
+			switch {
+			case p == policy.Automated:
+				addID(LabelAutomated, serviceID)
+			case p == policy.Locked:
+				addID(LabelLocked, serviceID)
+			default:
+				addID(LabelUpdatedPolicy, serviceID)
+			}
+		}
+		for p, _ := range u.Remove {
+			switch {
+			case p == policy.Automated:
+				addID(LabelDeautomated, serviceID)
+			case p == policy.Locked:
+				addID(LabelUnlocked, serviceID)
+			default:
+				addID(LabelUpdatedPolicy, serviceID)
+			}
+		}
+	}
+	return byType
+}

--- a/update/spec.go
+++ b/update/spec.go
@@ -3,14 +3,12 @@ package update
 import (
 	"encoding/json"
 	"errors"
-
-	"github.com/weaveworks/flux/policy"
 )
 
 const (
-	Images = "image"
-	Policy = "policy"
-	Auto   = "auto"
+	SpecImages = "image"
+	SpecPolicy = "policy"
+	SpecAuto   = "auto"
 )
 
 // How did this update get triggered?
@@ -40,19 +38,19 @@ func (spec *Spec) UnmarshalJSON(in []byte) error {
 	spec.Type = wire.Type
 	spec.Cause = wire.Cause
 	switch wire.Type {
-	case Policy:
-		var update policy.Updates
+	case SpecPolicy:
+		var update Policy
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
 		}
 		spec.Spec = update
-	case Images:
+	case SpecImages:
 		var update ReleaseSpec
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
 		}
 		spec.Spec = update
-	case Auto:
+	case SpecAuto:
 		var update Automated
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err


### PR DESCRIPTION
~Just one commit -- the other will be rebassed away once #1027 is merged.~ (EDIT: the rebass is accomplished)

The main change here is to move policy update specs into update/ and their application into release/, thus putting them in the same place as image updates (i.e, releases) and treating them more or less uniformly.

Part of this was breaking the dependence of the cluster package on the update package, which itself was a whisker away from depending on cluster. This'll make it easier to move more things around.