### PR TITLE
[WIP] add goreleaser as build/release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ testdata/sidecar/sidecar-linux-amd64
 testdata/sidecar/.sidecar
 docker/fluxy-dumbconf.priv
 test/profiles
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,53 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - dep ensure -vendor-only
+builds:
+- binary: fluxctl
+  main: ./cmd/fluxctl/
+  goos:
+    - linux
+    - darwin
+    - windows
+  env:
+   - CGO_ENABLED=0
+  goarch:
+    - amd64
+    - arm
+- binary: fluxd
+  main: ./cmd/fluxd/
+  goos:
+    - linux
+  env:
+   - CGO_ENABLED=0
+  goarch:
+    - amd64
+    - arm
+- binary: helm-operator
+  main: ./cmd/helm-operator/
+  goos:
+    - linux
+  env:
+   - CGO_ENABLED=0
+  goarch:
+    - amd64
+    - arm
+archive:
+  # format: binary
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
As a first step to fix #1377, I begin to work on `goreleaser`.

First major problem for this to be merged:
* I don't decorrelate `helm-operator` from `fluxctl`/`fluxd`.  
It, maybe, can be done with 2 different files but I suggest slipping this 2 projects into 2 different repo...
* I didn't add CI
* I didn't add snap / deb / rpm building (easy but waiting for your input about this work)