### PR TITLE
Read-only mode

### DIFF
--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -28,6 +28,7 @@ const (
 	ReadOnlySystem   ReadOnlyReason = "System"
 	ReadOnlyNoRepo   ReadOnlyReason = "NoRepo"
 	ReadOnlyNotReady ReadOnlyReason = "NotReady"
+	ReadOnlyROMode   ReadOnlyReason = "ReadOnlyMode"
 )
 
 type ControllerStatus struct {

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -161,10 +161,12 @@ running:
 fluxctl identity
 ```
 
-In order to sync your cluster state with GitHub you need to copy the public key and
-create a deploy key with write access on your GitHub repository.
-Go to _Settings > Deploy keys_ click on _Add deploy key_, check
-_Allow write access_, paste the Flux public key and click _Add key_.
+In order to sync your cluster state with GitHub you need to copy the
+public key and create a deploy key with access on your GitHub
+repository.  Go to _Settings > Deploy keys_ click on _Add deploy key_,
+paste the Flux public key and click _Add key_. If you want Flux to
+have write access to your repo, check _Allow write access_; if you
+have set `git.readonly=true`, you can leave this box unchecked.
 
 ### Uninstalling the Chart
 
@@ -208,7 +210,9 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `clusterRole.create`                              | `true`                                               | If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
 | `service.port`                                    | `3030`                                               | Service port to be used
+| `sync.state`                                      | `git`                                                | Where to keep sync state; either a tag in the upstream repo (`git`), or as an annotation on the SSH secret (`secret`)
 | `git.url`                                         | `None`                                               | URL of git repo with Kubernetes manifests
+| `git.readonly`                                    | `false`                                              | If `true`, the git repo will be considered read-only, and Flux will not attempt to write to it
 | `git.branch`                                      | `master`                                             | Branch of git repo to use for Kubernetes manifests
 | `git.path`                                        | `None`                                               | Path within git repo to locate Kubernetes manifests (relative path)
 | `git.user`                                        | `Weave Flux`                                         | Username to use as git committer

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -169,12 +169,14 @@ spec:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
           - --memcached-hostname={{ template "flux.fullname" . }}-memcached
+          - --sync-state={{ .Values.sync.state }}
           {{- if .Values.memcached.createClusterIP }}
           - --memcached-service=
           {{- end }}
           - --git-url={{ .Values.git.url }}
           - --git-branch={{ .Values.git.branch }}
           - --git-path={{ .Values.git.path }}
+          - --git-readonly={{ .Values.git.readonly }}
           - --git-user={{ .Values.git.user }}
           - --git-email={{ .Values.git.email }}
           {{- if (and .Values.gpgKeys.secretName .Values.gpgKeys.configMapName) }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -144,6 +144,10 @@ gpgKeys:
   # signatures of commits.
   configMapName: ""
 
+sync:
+  # use `.sync.state: secret` to store flux's state as an annotation on the secret (instead of a git tag)
+  state: git
+
 git:
   # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/weaveworks/flux-get-started
   url: ""
@@ -151,6 +155,9 @@ git:
   branch: "master"
   # Path within git repo to locate Kubernetes manifests (relative path)
   path: ""
+  # Set to `true` if you intend for Flux to not be able to push changes to git.
+  # Also configure state.mode to `secret` since storing state in a git tag will no longer be possible.
+  readonly: false
   # Username to use as git committer
   user: "Weave Flux"
   # Email to use as git committer

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -472,7 +472,7 @@ func TestDaemon_Release(t *testing.T) {
 		}
 		defer co.Clean()
 		// open a file
-		dirs := co.ManifestDirs()
+		dirs := co.AbsolutePaths()
 		if file, err := os.Open(filepath.Join(dirs[0], "helloworld-deploy.yaml")); err == nil {
 
 			// make sure it gets closed
@@ -517,7 +517,7 @@ func TestDaemon_PolicyUpdate(t *testing.T) {
 			return false
 		}
 		defer co.Clean()
-		cm := manifests.NewRawFiles(co.Dir(), co.ManifestDirs(), d.Manifests)
+		cm := manifests.NewRawFiles(co.Dir(), co.AbsolutePaths(), d.Manifests)
 		m, err := cm.GetAllResourcesByID(context.TODO())
 		if err != nil {
 			t.Fatalf("Error: %s", err.Error())
@@ -861,7 +861,7 @@ func (w *wait) ForImageTag(t *testing.T, d *Daemon, workload, container, tag str
 			return false
 		}
 		defer co.Clean()
-		cm := manifests.NewRawFiles(co.Dir(), co.ManifestDirs(), d.Manifests)
+		cm := manifests.NewRawFiles(co.Dir(), co.AbsolutePaths(), d.Manifests)
 		resources, err := cm.GetAllResourcesByID(context.TODO())
 		assert.NoError(t, err)
 

--- a/daemon/sync_test.go
+++ b/daemon/sync_test.go
@@ -258,7 +258,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 			return err
 		}
 		// Push some new changes
-		cm := manifests.NewRawFiles(checkout.Dir(), checkout.ManifestDirs(), d.Manifests)
+		cm := manifests.NewRawFiles(checkout.Dir(), checkout.AbsolutePaths(), d.Manifests)
 		resourcesByID, err := cm.GetAllResourcesByID(context.TODO())
 		if err != nil {
 			return err

--- a/daemon/sync_test.go
+++ b/daemon/sync_test.go
@@ -157,7 +157,7 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	var syncTag = "syncity"
 
 	ctx := context.Background()
-	err := d.WithClone(ctx, func(co *git.Checkout) error {
+	err := d.WithWorkingClone(ctx, func(co *git.Checkout) error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		tagAction := git.TagAction{
@@ -239,7 +239,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	var syncTag = "syncy-mcsyncface"
 	// Set the sync tag to head
 	var oldRevision, newRevision string
-	err := d.WithClone(ctx, func(checkout *git.Checkout) error {
+	err := d.WithWorkingClone(ctx, func(checkout *git.Checkout) error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 

--- a/daemon/sync_test.go
+++ b/daemon/sync_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/weaveworks/flux/manifests"
 	registryMock "github.com/weaveworks/flux/registry/mock"
 	"github.com/weaveworks/flux/resource"
+	fluxsync "github.com/weaveworks/flux/sync"
 )
 
 const (
 	gitPath     = ""
-	gitSyncTag  = "flux-sync"
 	gitNotesRef = "flux"
 	gitUser     = "Flux"
 	gitEmail    = "support@weave.works"
@@ -57,7 +57,6 @@ func daemon(t *testing.T) (*Daemon, func()) {
 
 	gitConfig := git.Config{
 		Branch:    "master",
-		SyncTag:   gitSyncTag,
 		NotesRef:  gitNotesRef,
 		UserName:  gitUser,
 		UserEmail: gitEmail,
@@ -109,9 +108,12 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	syncTag := lastKnownSyncTag{logger: d.Logger, syncTag: d.GitConfig.SyncTag}
 
-	if err := d.Sync(ctx, time.Now().UTC(), head, &syncTag); err != nil {
+	syncTag := "sync"
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", false, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	if err := d.Sync(ctx, time.Now().UTC(), head, syncState); err != nil {
 		t.Error(err)
 	}
 
@@ -141,7 +143,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 	// It creates the tag at HEAD
 	if err := d.Repo.Refresh(context.Background()); err != nil {
 		t.Errorf("pulling sync tag: %v", err)
-	} else if revs, err := d.Repo.CommitsBefore(context.Background(), gitSyncTag); err != nil {
+	} else if revs, err := d.Repo.CommitsBefore(context.Background(), syncTag); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if len(revs) <= 0 {
 		t.Errorf("Found no revisions before the sync tag")
@@ -152,15 +154,18 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	d, cleanup := daemon(t)
 	defer cleanup()
 
+	var syncTag = "syncity"
+
 	ctx := context.Background()
 	err := d.WithClone(ctx, func(co *git.Checkout) error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		tagAction := git.TagAction{
-			Revision: "HEAD",
+			Tag:      syncTag,
+			Revision: "master",
 			Message:  "Sync pointer",
 		}
-		return co.MoveSyncTagAndPush(ctx, tagAction)
+		return co.MoveTagAndPush(ctx, tagAction)
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -189,9 +194,11 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	syncTag := lastKnownSyncTag{logger: d.Logger, syncTag: d.GitConfig.SyncTag}
 
-	if err := d.Sync(ctx, time.Now().UTC(), head, &syncTag); err != nil {
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", false, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	if err := d.Sync(ctx, time.Now().UTC(), head, syncState); err != nil {
 		t.Error(err)
 	}
 
@@ -211,12 +218,12 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	}
 
 	// It doesn't move the tag
-	oldRevs, err := d.Repo.CommitsBefore(ctx, gitSyncTag)
+	oldRevs, err := d.Repo.CommitsBefore(ctx, syncTag)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if revs, err := d.Repo.CommitsBefore(ctx, gitSyncTag); err != nil {
+	if revs, err := d.Repo.CommitsBefore(ctx, syncTag); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if !reflect.DeepEqual(revs, oldRevs) {
 		t.Errorf("Should have kept the sync tag at HEAD")
@@ -228,6 +235,8 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
+
+	var syncTag = "syncy-mcsyncface"
 	// Set the sync tag to head
 	var oldRevision, newRevision string
 	err := d.WithClone(ctx, func(checkout *git.Checkout) error {
@@ -236,10 +245,11 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 
 		var err error
 		tagAction := git.TagAction{
-			Revision: "HEAD",
+			Tag:      syncTag,
+			Revision: "master",
 			Message:  "Sync pointer",
 		}
-		err = checkout.MoveSyncTagAndPush(ctx, tagAction)
+		err = checkout.MoveTagAndPush(ctx, tagAction)
 		if err != nil {
 			return err
 		}
@@ -303,9 +313,11 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	syncTag := lastKnownSyncTag{logger: d.Logger, syncTag: d.GitConfig.SyncTag}
 
-	if err := d.Sync(ctx, time.Now().UTC(), head, &syncTag); err != nil {
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", false, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	if err := d.Sync(ctx, time.Now().UTC(), head, syncState); err != nil {
 		t.Error(err)
 	}
 
@@ -337,7 +349,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	defer cancel()
 	if err := d.Repo.Refresh(ctx); err != nil {
 		t.Errorf("pulling sync tag: %v", err)
-	} else if revs, err := d.Repo.CommitsBetween(ctx, oldRevision, gitSyncTag); err != nil {
+	} else if revs, err := d.Repo.CommitsBetween(ctx, oldRevision, syncTag); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if len(revs) <= 0 {
 		t.Errorf("Should have moved sync tag forward")

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -143,6 +143,12 @@ spec:
         # Include this to enable git signature verification
         # - --git-verify-signatures
 
+        # Tell flux it has readonly access to the repo (default `false`)
+        # - --git-readonly
+
+        # Instruct flux where to put sync bookkeeping (default "git", meaning use a tag in the upstream git repo)
+        # - --sync-state=git
+
         # Include these next two to connect to an "upstream" service
         # (e.g., Weave Cloud). The token is particular to the service.
         # - --connect=wss://cloud.weave.works/api/flux

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -107,6 +107,15 @@ The image tag will be updated in the git repository upon applying the command.
 
 For more information about Flux commands see [the `fluxctl` docs](references/fluxctl.md).
 
+### Can I run Flux with readonly Git access?
+
+Yes. You can use the `--git-readonly` command line argument.  The Helm
+chart exposes this as `git.readonly`.
+
+This will prevent Flux from trying to write to your repository. You
+should also provide a readonly SSH key; e.g., on GitHub, leave the
+`Allow write access` box unchecked when you add the deploy key.
+
 ### Does Flux automatically sync changes back to git?
 
 No. It applies changes to git only when a Flux command or API call makes them.

--- a/git/errors.go
+++ b/git/errors.go
@@ -114,7 +114,8 @@ create a new deploy key. To create a new one, use
     fluxctl identity --regenerate
 
 The public key this outputs can then be given to GitHub; make sure you
-check the box to allow write access.
+check the box to allow write access unless you're using the
+--git-readonly=true option.
 
 `,
 	}

--- a/git/export.go
+++ b/git/export.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"os"
+	"path/filepath"
 )
 
 type Export struct {
@@ -29,4 +30,15 @@ func (r *Repo) Export(ctx context.Context, ref string) (*Export, error) {
 		return nil, err
 	}
 	return &Export{dir}, nil
+}
+
+// ChangedFiles does a git diff listing changed files
+func (c *Export) ChangedFiles(ctx context.Context, sinceRef string, paths []string) ([]string, error) {
+	list, err := changed(ctx, c.Dir(), sinceRef, paths)
+	if err == nil {
+		for i, file := range list {
+			list[i] = filepath.Join(c.Dir(), file)
+		}
+	}
+	return list, err
 }

--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -74,11 +74,11 @@ func Workloads() (res []resource.ID) {
 
 // CheckoutWithConfig makes a standard repo, clones it, and returns
 // the clone, the original repo, and a cleanup function.
-func CheckoutWithConfig(t *testing.T, config git.Config) (*git.Checkout, *git.Repo, func()) {
+func CheckoutWithConfig(t *testing.T, config git.Config, syncTag string) (*git.Checkout, *git.Repo, func()) {
 	// Add files to the repo with the same name as the git branch and the sync tag.
 	// This is to make sure that git commands don't have ambiguity problems between revisions and files.
 	testfiles.Files[config.Branch] = "Filename doctored to create a conflict with the git branch name"
-	testfiles.Files[config.SyncTag] = "Filename doctored to create a conflict with the git sync tag"
+	testfiles.Files[syncTag] = "Filename doctored to create a conflict with the git sync tag"
 	repo, cleanup := Repo(t)
 	if err := repo.Ready(context.Background()); err != nil {
 		cleanup()
@@ -94,7 +94,7 @@ func CheckoutWithConfig(t *testing.T, config git.Config) (*git.Checkout, *git.Re
 		co.Clean()
 		cleanup()
 		delete(testfiles.Files, config.Branch)
-		delete(testfiles.Files, config.SyncTag)
+		delete(testfiles.Files, syncTag)
 	}
 }
 
@@ -102,14 +102,15 @@ var TestConfig git.Config = git.Config{
 	Branch:    "master",
 	UserName:  "example",
 	UserEmail: "example@example.com",
-	SyncTag:   "flux-test",
 	NotesRef:  "fluxtest",
 }
+
+var testSyncTag = "sync"
 
 // Checkout makes a standard repo, clones it, and returns the clone
 // with a cleanup function.
 func Checkout(t *testing.T) (*git.Checkout, func()) {
-	checkout, _, cleanup := CheckoutWithConfig(t, TestConfig)
+	checkout, _, cleanup := CheckoutWithConfig(t, TestConfig, testSyncTag)
 	return checkout, cleanup
 }
 

--- a/git/gittest/repo_test.go
+++ b/git/gittest/repo_test.go
@@ -28,7 +28,7 @@ func TestCommit(t *testing.T) {
 	defer cleanup()
 
 	for file, _ := range testfiles.Files {
-		dirs := checkout.ManifestDirs()
+		dirs := checkout.AbsolutePaths()
 		path := filepath.Join(dirs[0], file)
 		if err := ioutil.WriteFile(path, []byte("FIRST CHANGE"), 0666); err != nil {
 			t.Fatal(err)
@@ -84,7 +84,7 @@ func TestSignedCommit(t *testing.T) {
 	defer cleanup()
 
 	for file, _ := range testfiles.Files {
-		dirs := checkout.ManifestDirs()
+		dirs := checkout.AbsolutePaths()
 		path := filepath.Join(dirs[0], file)
 		if err := ioutil.WriteFile(path, []byte("FIRST CHANGE"), 0666); err != nil {
 			t.Fatal(err)
@@ -199,7 +199,7 @@ func TestCheckout(t *testing.T) {
 	}
 
 	changedFile := ""
-	dirs := checkout.ManifestDirs()
+	dirs := checkout.AbsolutePaths()
 	for file, _ := range testfiles.Files {
 		path := filepath.Join(dirs[0], file)
 		if err := ioutil.WriteFile(path, []byte("FIRST CHANGE"), 0666); err != nil {

--- a/git/gittest/repo_test.go
+++ b/git/gittest/repo_test.go
@@ -190,7 +190,7 @@ func TestCheckout(t *testing.T) {
 	}
 
 	var note Note
-	ok, err := checkout.GetNote(ctx, head, &note)
+	ok, err := repo.GetNote(ctx, head, params.NotesRef, &note)
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,7 +241,7 @@ func TestCheckout(t *testing.T) {
 		}
 
 		var note Note
-		ok, err := c.GetNote(ctx, rev, &note)
+		ok, err := repo.GetNote(ctx, rev, params.NotesRef, &note)
 		if !ok {
 			t.Error("note not found")
 		}

--- a/git/repo.go
+++ b/git/repo.go
@@ -254,6 +254,15 @@ func (r *Repo) VerifyCommit(ctx context.Context, commit string) error {
 	return verifyCommit(ctx, r.dir, commit)
 }
 
+func (r *Repo) DeleteTag(ctx context.Context, tag string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if err := r.errorIfNotReady(); err != nil {
+		return err
+	}
+	return deleteTag(ctx, r.dir, tag, r.origin.URL)
+}
+
 // step attempts to advance the repo state machine, and returns `true`
 // if it has made progress, `false` otherwise.
 func (r *Repo) step(bg context.Context) bool {

--- a/git/repo.go
+++ b/git/repo.go
@@ -273,6 +273,15 @@ func (r *Repo) DeleteTag(ctx context.Context, tag string) error {
 	return deleteTag(ctx, r.dir, tag, r.origin.URL)
 }
 
+func (r *Repo) NoteRevList(ctx context.Context, notesRef string) (map[string]struct{}, error) {
+	return noteRevList(ctx, r.Dir(), notesRef)
+}
+
+// GetNote gets a note for the revision specified, or nil if there is no such note.
+func (r *Repo) GetNote(ctx context.Context, rev, notesRef string, note interface{}) (bool, error) {
+	return getNote(ctx, r.Dir(), notesRef, rev, note)
+}
+
 // step attempts to advance the repo state machine, and returns `true`
 // if it has made progress, `false` otherwise.
 func (r *Repo) step(bg context.Context) bool {

--- a/git/repo.go
+++ b/git/repo.go
@@ -127,6 +127,12 @@ func (r *Repo) Origin() Remote {
 	return r.origin
 }
 
+// Readonly returns `true` if the repo was marked as readonly, `false`
+// otherwise
+func (r *Repo) Readonly() bool {
+	return r.readonly
+}
+
 // Dir returns the local directory into which the repo has been
 // cloned, if it has been cloned.
 func (r *Repo) Dir() string {

--- a/git/repo.go
+++ b/git/repo.go
@@ -91,9 +91,13 @@ func (b Branch) apply(r *Repo) {
 	r.branch = string(b)
 }
 
-var ReadOnly optionFunc = func(r *Repo) {
-	r.readonly = true
+type IsReadOnly bool
+
+func (ro IsReadOnly) apply(r *Repo) {
+	r.readonly = bool(ro)
 }
+
+var ReadOnly IsReadOnly = true
 
 // NewRepo constructs a repo mirror which will sync itself.
 func NewRepo(origin Remote, opts ...Option) *Repo {

--- a/git/working.go
+++ b/git/working.go
@@ -16,7 +16,6 @@ var (
 type Config struct {
 	Branch      string   // branch we're syncing to
 	Paths       []string // paths within the repo containing files we care about
-	SyncTag     string
 	NotesRef    string
 	UserName    string
 	UserEmail   string
@@ -42,15 +41,16 @@ type Commit struct {
 	Message   string
 }
 
-// CommitAction - struct holding commit information
+// CommitAction is a struct holding commit information
 type CommitAction struct {
 	Author     string
 	Message    string
 	SigningKey string
 }
 
-// TagAction - struct holding tag information
+// TagAction is a struct holding tag parameters
 type TagAction struct {
+	Tag        string
 	Revision   string
 	Message    string
 	SigningKey string
@@ -198,19 +198,11 @@ func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
 	return refRevision(ctx, c.dir, "HEAD")
 }
 
-func (c *Checkout) SyncRevision(ctx context.Context) (string, error) {
-	return refRevision(ctx, c.dir, "tags/"+c.config.SyncTag)
-}
-
-func (c *Checkout) MoveSyncTagAndPush(ctx context.Context, tagAction TagAction) error {
+func (c *Checkout) MoveTagAndPush(ctx context.Context, tagAction TagAction) error {
 	if tagAction.SigningKey == "" {
 		tagAction.SigningKey = c.config.SigningKey
 	}
-	return moveTagAndPush(ctx, c.dir, c.config.SyncTag, c.upstream.URL, tagAction)
-}
-
-func (c *Checkout) VerifySyncTag(ctx context.Context) (string, error) {
-	return verifyTag(ctx, c.dir, c.config.SyncTag)
+	return moveTagAndPush(ctx, c.dir, c.upstream.URL, tagAction)
 }
 
 // ChangedFiles does a git diff listing changed files

--- a/git/working.go
+++ b/git/working.go
@@ -164,7 +164,7 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction,
 		if err != nil {
 			return err
 		}
-		if err := addNote(ctx, c.Dir(), rev, c.config.NotesRef, note); err != nil {
+		if err := addNote(ctx, c.Dir(), rev, c.realNotesRef, note); err != nil {
 			return err
 		}
 	}
@@ -183,11 +183,6 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction,
 	return nil
 }
 
-// GetNote gets a note for the revision specified, or nil if there is no such note.
-func (c *Checkout) GetNote(ctx context.Context, rev string, note interface{}) (bool, error) {
-	return getNote(ctx, c.Dir(), c.realNotesRef, rev, note)
-}
-
 func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
 	return refRevision(ctx, c.Dir(), "HEAD")
 }
@@ -197,21 +192,6 @@ func (c *Checkout) MoveTagAndPush(ctx context.Context, tagAction TagAction) erro
 		tagAction.SigningKey = c.config.SigningKey
 	}
 	return moveTagAndPush(ctx, c.Dir(), c.upstream.URL, tagAction)
-}
-
-// ChangedFiles does a git diff listing changed files
-func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, error) {
-	list, err := changed(ctx, c.Dir(), ref, c.config.Paths)
-	if err == nil {
-		for i, file := range list {
-			list[i] = filepath.Join(c.Dir(), file)
-		}
-	}
-	return list, err
-}
-
-func (c *Checkout) NoteRevList(ctx context.Context) (map[string]struct{}, error) {
-	return noteRevList(ctx, c.Dir(), c.realNotesRef)
 }
 
 func (c *Checkout) Checkout(ctx context.Context, rev string) error {

--- a/git/working.go
+++ b/git/working.go
@@ -59,10 +59,6 @@ type TagAction struct {
 // Clone returns a local working clone of the sync'ed `*Repo`, using
 // the config given.
 func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
-	if r.readonly {
-		return nil, ErrReadOnly
-	}
-
 	upstream := r.Origin()
 	repoDir, err := r.workingClone(ctx, conf.Branch)
 	if err != nil {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -162,7 +162,7 @@ func mockCluster(running ...cluster.Workload) *mock.Mock {
 }
 
 func NewManifestStoreOrFail(t *testing.T, parser manifests.Manifests, checkout *git.Checkout) manifests.Store {
-	cm := manifests.NewRawFiles(checkout.Dir(), checkout.ManifestDirs(), parser)
+	cm := manifests.NewRawFiles(checkout.Dir(), checkout.AbsolutePaths(), parser)
 	return cm
 }
 

--- a/sync/git.go
+++ b/sync/git.go
@@ -1,0 +1,86 @@
+package sync
+
+import (
+	"context"
+	"strings"
+
+	"github.com/weaveworks/flux/git"
+)
+
+// GitTagSyncProvider is the mechanism by which a Git tag is used to keep track of the current point fluxd has synced to.
+type GitTagSyncProvider struct {
+	repo       *git.Repo
+	syncTag    string
+	signingKey string
+	verifyTag  bool
+	config     git.Config
+}
+
+// NewGitTagSyncProvider creates a new git tag sync provider.
+func NewGitTagSyncProvider(
+	repo *git.Repo,
+	syncTag string,
+	signingKey string,
+	verifyTag bool,
+	config git.Config,
+) (GitTagSyncProvider, error) {
+	return GitTagSyncProvider{
+		repo:       repo,
+		syncTag:    syncTag,
+		signingKey: signingKey,
+		verifyTag:  verifyTag,
+		config:     config,
+	}, nil
+}
+
+func (p GitTagSyncProvider) String() string {
+	return "tag " + p.syncTag
+}
+
+// GetRevision returns the revision of the git commit where the flux sync tag is currently positioned.
+func (p GitTagSyncProvider) GetRevision(ctx context.Context) (string, error) {
+	rev, err := p.repo.Revision(ctx, p.syncTag)
+	if isUnknownRevision(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	if p.verifyTag {
+		if _, err := p.repo.VerifyTag(ctx, p.syncTag); err != nil {
+			// if the revision wasn't found, don't treat this as an
+			// error -- but don't supply a revision, either.
+			if strings.Contains(err.Error(), "not found.") {
+				return "", nil
+			}
+			return "", err
+		}
+	}
+	return rev, nil
+}
+
+// UpdateMarker moves the sync tag in the upstream repo.
+func (p GitTagSyncProvider) UpdateMarker(ctx context.Context, revision string) error {
+	checkout, err := p.repo.Clone(ctx, p.config)
+	if err != nil {
+		return err
+	}
+	return checkout.MoveTagAndPush(ctx, git.TagAction{
+		Tag:        p.syncTag,
+		Revision:   revision,
+		Message:    "Sync pointer",
+		SigningKey: p.signingKey,
+	})
+}
+
+// DeleteMarker removes the Git Tag used for syncing.
+func (p GitTagSyncProvider) DeleteMarker(ctx context.Context) error {
+	return p.repo.DeleteTag(ctx, p.syncTag)
+}
+
+func isUnknownRevision(err error) bool {
+	return err != nil &&
+		(strings.Contains(err.Error(), "unknown revision or path not in the working tree.") ||
+			strings.Contains(err.Error(), "bad revision"))
+}

--- a/sync/provider.go
+++ b/sync/provider.go
@@ -1,0 +1,26 @@
+package sync
+
+import (
+	"context"
+)
+
+const (
+	// GitTagStateMode is a mode of state management where Flux uses a git tag for managing Flux state
+	GitTagStateMode = "git"
+
+	// NativeStateMode is a mode of state management where Flux uses native Kubernetes resources for managing Flux state
+	NativeStateMode = "secret"
+)
+
+type State interface {
+	// GetRevision fetches the recorded revision, returning an empty
+	// string if none has been recorded yet.
+	GetRevision(ctx context.Context) (string, error)
+	// UpdateMarker records the high water mark
+	UpdateMarker(ctx context.Context, revision string) error
+	// DeleteMarker removes the high water mark
+	DeleteMarker(ctx context.Context) error
+	// String returns a string representation of where the state is
+	// recorded (e.g., for referring to it in logs)
+	String() string
+}

--- a/sync/secret.go
+++ b/sync/secret.go
@@ -1,0 +1,92 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubernetes "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+const syncMarkerKey = "flux.weave.works/sync-hwm"
+
+// NativeSyncProvider keeps information related to the native state of a sync marker stored in a "native" kubernetes resource.
+type NativeSyncProvider struct {
+	namespace    string
+	revision     string
+	resourceName string
+	resourceAPI  v1.SecretInterface
+}
+
+// NewNativeSyncProvider creates a new NativeSyncProvider
+func NewNativeSyncProvider(namespace string, resourceName string) (NativeSyncProvider, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return NativeSyncProvider{}, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return NativeSyncProvider{}, err
+	}
+
+	return NativeSyncProvider{
+		resourceAPI:  clientset.CoreV1().Secrets(namespace),
+		namespace:    namespace,
+		resourceName: resourceName,
+	}, nil
+}
+
+func (p NativeSyncProvider) String() string {
+	return "kubernetes " + p.namespace + ":secret/" + p.resourceName
+}
+
+// GetRevision gets the revision of the current sync marker (representing the place flux has synced to).
+func (p NativeSyncProvider) GetRevision(ctx context.Context) (string, error) {
+	resource, err := p.resourceAPI.Get(p.resourceName, meta_v1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	revision, exists := resource.Annotations[syncMarkerKey]
+	if !exists {
+		return "", p.setRevision("")
+	}
+	return revision, nil
+}
+
+// UpdateMarker updates the revision the sync marker points to.
+func (p NativeSyncProvider) UpdateMarker(ctx context.Context, revision string) error {
+	return p.setRevision(revision)
+}
+
+// DeleteMarker resets the state of the object.
+func (p NativeSyncProvider) DeleteMarker(ctx context.Context) error {
+	return p.setRevision("")
+}
+
+func (p NativeSyncProvider) setRevision(revision string) error {
+	jsonPatch, err := json.Marshal(patch(revision))
+	if err != nil {
+		return err
+	}
+
+	_, err = p.resourceAPI.Patch(
+		p.resourceName,
+		types.StrategicMergePatchType,
+		jsonPatch,
+	)
+	return err
+}
+
+func patch(revision string) map[string]map[string]map[string]string {
+	return map[string]map[string]map[string]string{
+		"metadata": map[string]map[string]string{
+			"annotations": map[string]string{
+				syncMarkerKey: revision,
+			},
+		},
+	}
+}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -26,8 +26,8 @@ func TestSync(t *testing.T) {
 	parser := kubernetes.NewManifests(kubernetes.ConstNamespacer("default"), log.NewLogfmtLogger(os.Stdout))
 	clus := &syncCluster{map[string]string{}}
 
-	dirs := checkout.ManifestDirs()
-	rs := manifests.NewRawFiles(checkout.Dir(), checkout.ManifestDirs(), parser)
+	dirs := checkout.AbsolutePaths()
+	rs := manifests.NewRawFiles(checkout.Dir(), dirs, parser)
 	resources, err := rs.GetAllResourcesByID(context.TODO())
 	if err != nil {
 		t.Fatal(err)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -42,7 +42,6 @@ func TestSync(t *testing.T) {
 // ---
 
 var gitconf = git.Config{
-	SyncTag:   "test-sync",
 	NotesRef:  "test-notes",
 	UserName:  "testuser",
 	UserEmail: "test@example.com",


### PR DESCRIPTION
closes #1139 

I am opening this draft PR just to provide some early context for the direction I'm going with enabling a read-only mode for Flux.  I have a lot more to say to fill out the discussion of this post, so I'll be updating this description as more findings arise.  I am not only interested in talking about high-level architecture of this feature at this stage so please reserve your comments on anything else until later.

## Use Cases
I know of a few but haven't gotten them distilled into text quite yet.  If you have some in mind please comment below and I will add them here.

## Storing Flux's application state elsewhere
The main challenge with this mode is that Flux uses git for storing Flux's application state.  These fall down into two main pieces of data: (1) the "sync-tag" and (2) the usage of git notes.

### Replacing the sync-tag
This one, at surface level, looks simple enough.  The data held by the sync-tag boils down to a string holding the git reference for the commit that flux has currently synced to.  This string can be stored in native kubernetes storage such as:

1. inside a kubernetes Secret as a new key/value pair
    - **pro:** we already have a secret resource at our disposal
    - **con:** this data is not secret - and storing it in a Secret (compared to storing it in a ConfigMap) feels like an impedance mismatch
    - **pro:** the codebase is already familiar with how to work with and use a Secret (I think this should be an extremely minor consideration, but a consideration nonetheless)
    - **con:** 1MB size limit
1. inside a kubernetes ConfigMap as a new key/value pair
    - **con:** 1MB size limit
    - **meh:** requires creation of new resource... but... honestly... due to the popularity of the helm chart it is unlikely this is actually much of an issue at all
    - **con:** the codebase needs to be taught how to interact with ConfigMaps (not a big deal, I think, but still a consideration)
1. as an annotation on another kubernetes resource, perhaps the flux controller itself or the secret
    - **pro:** could be a simple option for some very simple data.
    - **pro:** doesn't require the creation of new kubernetes resources
    - **con:** 1MB size limit
1. an in-memory Go struct
    - **con:** not being persistent if the pod shuts down.  That's very undesirable - so much so that we should not consider this option further.
1. memcache
    - @squaremo has suggested that we should not scope creep the current role of memcache.  Although it's tempting to use as a source-of-truth database for these values, we will not strongly consider this option unless some other factors arise.
1. use data in a CRD
    - I am waiting on @stefanprodan to give me some more information on this, but he tells me there's a something to do with CRD "slice status" that is a new-ish kubernetes feature that will eventually be the resting place for a feature like this.
    - **pro:** it is likely that in the future we will move many things to a CRD anyway, so might not be bad to get a jump start now.
1. mirrored repo with read-only access
    - This is perhaps simultaneously the most exotic choice on the list as well as the most simple.  The idea here with this one would be to basically create a very thin layer on top of the readonly repo (a mirror) that flux _does_ have write access to.  All actions on the readonly repo would be mirrored onto the read/write repo and it is there on the read/write repo that flux would use the same state management strategies it uses today.  The problem is, this option doesn't scale.  It is unrealistic for a cloud provider, for example, to be interested in having to duplicate the entire git tree somewhere just to use flux.  Flux should simply be able to watch a repo and snyc the changes (read-only).

### Replacing the git notes
This one is a little trickier.  All of the above listed possibilities for storing the sync-tag are _potentially_ options here as well.  We can store this in a kubernetes resource so long as it doesn't ever have potential to go over 1mb, the limit imposed by kubernetes versions that Flux currently supports.  Currently I am unable to determine what the maximum size that the notes might reasonably reach because when I run `git notes list` on a repository that is using Flux on production, I don't get any results back.  **if someone can point me in the right direction on this one I would appreciate it**.

So far as I can tell the notes are used for webhooks and APIs for returning information about the activity of the repository.  It is not possible to release this readonly feature without retaining other primary features, in my opinion.

Currently there are errors associated with git tags that I am still working out in the codebase.

## Notes

Yes, I did change some variable names and function signatures in the public API that would constitute a breaking change of some sort.  Please ignore the implications any such changes until we get a working strategy for handling the architectural problems described above.

I have left some notes to self under `READONLY-NOTE:`-prepended comments in the codebase.  These will all be removed before merging.