### PR TITLE
RBAC improvements

### DIFF
--- a/deploy/flux-account.yaml
+++ b/deploy/flux-account.yaml
@@ -9,28 +9,15 @@ metadata:
   name: flux
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  labels:
-    name: flux
-  name: flux
-rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ['*']
-  - nonResourceURLs: ['*']
-    verbs: ['*']
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
     name: flux
   name: flux
 roleRef:
-  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: flux
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: flux


### PR DESCRIPTION
Remove the need for defining a custom cluster role and just bind to the k8s existing RBAC role for cluster admin
