### PR TITLE
Remove Weave Cloudness from fluxctl usage

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -31,7 +31,7 @@ type Token string
 
 func (t Token) Set(req *http.Request) {
 	if string(t) != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Scope-Probe token=%s", t))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t))
 	}
 }
 

--- a/http/websocket/websocket_test.go
+++ b/http/websocket/websocket_test.go
@@ -16,7 +16,7 @@ func TestToken(t *testing.T) {
 	token := "toooookkkkkeeeeennnnnn"
 	upgrade := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tok := r.Header.Get("Authorization")
-		if tok != "Scope-Probe token="+token {
+		if tok != "Bearer "+token {
 			t.Fatal("Did not get authorisation header, got: " + tok)
 		}
 		_, err := Upgrade(w, r, nil)


### PR DESCRIPTION
Removes Weave Cloud defaults from fluxctl.

 - Use an RFC6750 bearer token when connecting to an upstream service (Weave Cloud supports these; but it's also an easy, generic thing to support in any other such service)
 - Changes the behaviour of fluxctl so that you must supply both a URL and token to connect to an upstream service. Previously it was presumed you were connecting to Weave Cloud if you supplied a token at all.

The latter change is mildly backward _in_compatible, so we should be careful about rolling this out. In particular, any scripts or people that supply a token but not a URL to fluxctl will find that they get a warning, and fluxctl will probably try to using port-forwarding and fail.

Fixes #2182. 