### PR TITLE
Support both new fluxcd and original annotations

### DIFF
--- a/cluster/kubernetes/policies_test.go
+++ b/cluster/kubernetes/policies_test.go
@@ -23,13 +23,13 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "adding annotation with others existing",
 			in:   []string{"prometheus.io/scrape", "'false'"},
-			out:  []string{"prometheus.io/scrape", "'false'", "flux.weave.works/automated", "'true'"},
+			out:  []string{"prometheus.io/scrape", "'false'", "fluxcd.io/automated", "'true'"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.Automated: "true"},
 			},
 		},
 		{
-			name: "adding annotation when already has annotation",
+			name: "adding annotation when already has annotation does not change prefix",
 			in:   []string{"flux.weave.works/automated", "'true'"},
 			out:  []string{"flux.weave.works/automated", "'true'"},
 			update: resource.PolicyUpdate{
@@ -45,9 +45,9 @@ func TestUpdatePolicies(t *testing.T) {
 			},
 		},
 		{
-			name: "adding first annotation",
+			name: "adding first annotation (uses new prefix)",
 			in:   nil,
-			out:  []string{"flux.weave.works/automated", "'true'"},
+			out:  []string{"fluxcd.io/automated", "'true'"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.Automated: "true"},
 			},
@@ -55,7 +55,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add and remove different annotations at the same time",
 			in:   []string{"flux.weave.works/automated", "'true'", "prometheus.io/scrape", "'false'"},
-			out:  []string{"prometheus.io/scrape", "'false'", "flux.weave.works/locked", "'true'"},
+			out:  []string{"prometheus.io/scrape", "'false'", "fluxcd.io/locked", "'true'"},
 			update: resource.PolicyUpdate{
 				Add:    policy.Set{policy.Locked: "true"},
 				Remove: policy.Set{policy.Automated: "true"},
@@ -72,7 +72,7 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "remove annotation with others existing",
-			in:   []string{"flux.weave.works/automated", "true", "prometheus.io/scrape", "false"},
+			in:   []string{"fluxcd.io/automated", "true", "prometheus.io/scrape", "false"},
 			out:  []string{"prometheus.io/scrape", "false"},
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.Automated: "true"},
@@ -80,7 +80,7 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "remove last annotation",
-			in:   []string{"flux.weave.works/automated", "true"},
+			in:   []string{"fluxcd.io/automated", "true"},
 			out:  nil,
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.Automated: "true"},
@@ -104,7 +104,7 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "multiline",
-			in:   []string{"flux.weave.works/locked_msg", "|-\n      first\n      second"},
+			in:   []string{"fluxcd.io/locked_msg", "|-\n      first\n      second"},
 			out:  nil,
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.LockedMsg: "foo"},
@@ -112,7 +112,7 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "multiline with empty line",
-			in:   []string{"flux.weave.works/locked_msg", "|-\n      first\n\n      third"},
+			in:   []string{"fluxcd.io/locked_msg", "|-\n      first\n\n      third"},
 			out:  nil,
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.LockedMsg: "foo"},
@@ -121,7 +121,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "glob:*"},
+			out:  []string{"fluxcd.io/tag.nginx", "glob:*"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "glob:*"},
 			},
@@ -129,7 +129,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add non-glob tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "foo"},
+			out:  []string{"fluxcd.io/tag.nginx", "foo"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "foo"},
 			},
@@ -137,7 +137,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add semver tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "semver:*"},
+			out:  []string{"fluxcd.io/tag.nginx", "semver:*"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "semver:*"},
 			},
@@ -145,7 +145,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add invalid semver tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "semver:*"},
+			out:  []string{"fluxcd.io/tag.nginx", "semver:*"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "semver:invalid"},
 			},
@@ -154,7 +154,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add regexp tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "regexp:(.*?)"},
+			out:  []string{"fluxcd.io/tag.nginx", "regexp:(.*?)"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "regexp:(.*?)"},
 			},
@@ -162,7 +162,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "add invalid regexp tag policy",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "regexp:(.*?)"},
+			out:  []string{"fluxcd.io/tag.nginx", "regexp:(.*?)"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagPrefix("nginx"): "regexp:*"},
 			},
@@ -171,7 +171,7 @@ func TestUpdatePolicies(t *testing.T) {
 		{
 			name: "set tag to all containers",
 			in:   nil,
-			out:  []string{"flux.weave.works/tag.nginx", "semver:*"},
+			out:  []string{"fluxcd.io/tag.nginx", "semver:*"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.TagAll: "semver:*"},
 			},

--- a/manifests/configaware_test.go
+++ b/manifests/configaware_test.go
@@ -207,7 +207,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    flux.weave.works/tag.greeter: glob:master-*
+    fluxcd.io/tag.greeter: glob:master-*
   name: helloworld
 spec:
   template:


### PR DESCRIPTION
The new prefix for annotations is `fluxcd.io`; but, many files will
use `flux.weave.works`, and we don't want to suddenly not understand
the policies in those.

This commit adds support for interpreting and updating policies as
annotations with either prefix. When updating, if an annotation uses
the old prefix, that will be retained; otherwise, the new prefix is
used.

This change is backward-compatible, but we may want to keep it back until we're releasing other "decoupling" changes.

Fixes #2217.