### PR TITLE
Chart:  re-implement registry.ecr.require

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -190,6 +190,9 @@ spec:
           - --registry-rps={{ .Values.registry.rps }}
           - --registry-burst={{ .Values.registry.burst }}
           - --registry-trace={{ .Values.registry.trace }}
+          {{- if .Values.registry.ecr.require }}
+          - --registry-require=ecr
+          {{- end }}
           {{- if .Values.registry.insecureHosts }}
           - --registry-insecure-host={{ .Values.registry.insecureHosts }}
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -193,6 +193,7 @@ registry:
     region:
     includeId:
     excludeId:
+    require: false
   # Azure ACR settings
   acr:
     enabled: false


### PR DESCRIPTION
This parameter was not implemented.
