### PR TITLE
parse credentials without scheme

### DIFF
--- a/registry/credentials_test.go
+++ b/registry/credentials_test.go
@@ -40,6 +40,10 @@ func TestRemoteFactory_ParseHost(t *testing.T) {
 			imagePrefix: "localhost:5000",
 		},
 		{
+			host:        "192.168.99.100:5000",
+			imagePrefix: "192.168.99.100:5000",
+		},
+		{
 			host:        "https://192.168.99.100:5000/v2",
 			imagePrefix: "192.168.99.100:5000",
 		},


### PR DESCRIPTION
When the host within the docker config has format IP:PORT
url.Parse(host) fails. This commit will first try re-parsing
with prepended scheme before returning any error.