### PR TITLE
Fixed `rollback.timeout` type definition in CRD

### DIFF
--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -55,7 +55,8 @@ spec:
                 disableHooks:
                   type: boolean
                 timeout:
-                  type: int64
+                  type: integer
+                  format: int64
                 wait:
                   type: boolean
             valueFileSecrets:

--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -47,7 +47,8 @@ spec:
                 disableHooks:
                   type: boolean
                 timeout:
-                  type: int64
+                  type: integer
+                  format: int64
                 wait:
                   type: boolean
             valueFileSecrets:


### PR DESCRIPTION
Trying to a apply a `HelmRelease` with a set `rollback.timeout` would
result in a validation error: `spec.rollback.timeout in body must be of
type int64: "integer"`.

This was due to the fact that the validation scheme definition contained
a mistake, the `type` should be `integer` and the format is `int64`.

Fixes #2250 