### PR TITLE
Use correct Helm repository domain in docs

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -47,7 +47,7 @@ You will have a fully working Flux installation deploying workloads to your clus
 Add the weaveworks repo:
 
 ```sh
-helm repo add weaveworks https://weaveworks.github.io/flux
+helm repo add fluxcd https://fluxcd.github.io/flux
 ```
 
 #### To install the chart with the release name `flux`
@@ -58,7 +58,7 @@ Replace `weaveworks/flux-get-started` with your own git repository and run helm 
 $ helm install --name flux \
 --set git.url=git@github.com:weaveworks/flux-get-started \
 --namespace flux \
-weaveworks/flux
+fluxcd/flux
 ```
 
 #### To connect Flux to a Weave Cloud instance:
@@ -68,7 +68,7 @@ helm install --name flux \
 --set git.url=git@github.com:weaveworks/flux-get-started \
 --set token=YOUR_WEAVE_CLOUD_SERVICE_TOKEN \
 --namespace flux \
-weaveworks/flux
+fluxcd/flux
 ```
 
 #### To install Flux with the Helm operator:
@@ -87,7 +87,7 @@ $ helm install --name flux \
 --set helmOperator.create=true \
 --set helmOperator.createCRD=false \
 --namespace flux \
-weaveworks/flux
+fluxcd/flux
 ```
 
 #### To install Flux with a private git host:

--- a/site/annotations-tutorial.md
+++ b/site/annotations-tutorial.md
@@ -74,13 +74,13 @@ Now you can take care of the actual installation. First add the Flux
 repository of Weaveworks:
 
 ```sh
-helm repo add weaveworks https://weaveworks.github.io/flux
+helm repo add fluxcd https://fluxcd.github.io/flux
 ```
 
 Apply the Helm Release CRD:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluxcd/flux/master/deploy-helm/flux-helm-release-crd.yaml
 ```
 
 Install Flux and its Helm Operator by specifying your fork URL. Just
@@ -93,7 +93,7 @@ helm upgrade -i Flux \
 --set helmOperator.createCRD=false \
 --set git.url=git@github.com:YOURUSER/flux-get-started \
 --namespace default \
-weaveworks/flux
+fluxcd/flux
 ```
 
 > **Note:** In this tutorial we keep things simple, so we deploy Flux into

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -184,7 +184,7 @@ kubectl create secret tls helm-client --cert=tls/flux-helm-operator.pem --key=./
 Deploy Flux with Helm;
 
 ```bash
-helm repo add weaveworks https://weaveworks.github.io/flux
+helm repo add fluxcd https://fluxcd.github.io/flux
 
 helm upgrade --install \
     --set helmOperator.create=true \
@@ -194,7 +194,7 @@ helm upgrade --install \
     --set helmOperator.tls.secretName=helm-client \
     --set helmOperator.tls.caContent="$(cat ./tls/ca.pem)" \
     flux \
-    weaveworks/flux
+    fluxcd/flux
 ```
 > **Note:**
 > - include --tls flags for `helm` as in the `helm ls` example, if talking to a tiller with TLS


### PR DESCRIPTION
As it has changed after our move to the `fluxcd` organization, and
the old URL no longer works.