### PR TITLE
Added a simple kustomize.yaml for deploying flux

### DIFF
--- a/deploy-kustomize/kustomization.yaml
+++ b/deploy-kustomize/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../deploy/flux-account.yaml
+- ../deploy/flux-deployment.yaml
+- ../deploy/flux-secret.yaml
+- ../deploy/memcache-dep.yaml
+- ../deploy/memcache-svc.yaml

--- a/deploy-kustomize/kustomization.yaml
+++ b/deploy-kustomize/kustomization.yaml
@@ -1,6 +1,0 @@
-resources:
-- ../deploy/flux-account.yaml
-- ../deploy/flux-deployment.yaml
-- ../deploy/flux-secret.yaml
-- ../deploy/memcache-dep.yaml
-- ../deploy/memcache-svc.yaml

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- flux-account.yaml
+- flux-deployment.yaml
+- flux-secret.yaml
+- memcache-dep.yaml
+- memcache-svc.yaml


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

Added a simple `kustomization.yaml` which defines the flux manifests as resources. This will allow others to use this repo as a remote base and use `kustomize` to apply their desired configuration instead of having to duplicate the manifests in their own repos.

For example:

```
DEMO=$(mktemp -d)

cat <<EOF >$DEMO/kustomization.yaml
bases:
- git@github.com:fluxcd/flux//deploy-kustomize

patchesStrategicMerge:
- args-patch.yaml
EOF

cat <<EOF >$DEMO/args-patch.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: flux
spec:
  template:
    spec:
      containers:
      - name: flux
        args:
        - --git-url=git@github.com:example/manifests
EOF
```