### PR TITLE
Make `fluxctl` respect the kube config context NS

### DIFF
--- a/cmd/fluxctl/args.go
+++ b/cmd/fluxctl/args.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/flux/update"
@@ -48,4 +50,21 @@ func getUserGitConfigValue(arg string) string {
 	}
 	res := out.String()
 	return strings.Trim(res, "\x00")
+}
+
+var getKubeConfigContextNamespace = func(defaultNamespace string) string {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil {
+		return defaultNamespace
+	}
+
+	cc := config.CurrentContext
+	if c, ok := config.Contexts[cc]; ok && c.Namespace != "" {
+		return c.Namespace
+	}
+
+	return defaultNamespace
 }

--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadAutomateOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Workload namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to automate")
 
 	// Deprecated

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadDeautomateOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Workload namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to deautomate")
 
 	// Deprecated

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -36,7 +36,7 @@ func (opts *imageListOpts) Command() *cobra.Command {
 		Example: makeExample("fluxctl list-images --namespace default --workload=deployment/foo"),
 		RunE:    opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace(""), "Namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Show images for this workload")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "l", 10, "Number of images to show (0 for all)")
 

--- a/cmd/fluxctl/list_workloads_cmd.go
+++ b/cmd/fluxctl/list_workloads_cmd.go
@@ -30,7 +30,7 @@ func (opts *workloadListOpts) Command() *cobra.Command {
 		Example: makeExample("fluxctl list-workloads"),
 		RunE:    opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Confine query to namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Confine query to namespace")
 	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "a", false, "Query across all namespaces")
 	return cmd
 }

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadLockOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Controller namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Controller namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to lock")
 
 	// Deprecated

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -60,7 +60,7 @@ containers which aren't explicitly named.
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.namespace, "namespace", "n", "default", "Workload namespace")
+	flags.StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
 	flags.StringVarP(&opts.workload, "workload", "w", "", "Workload to modify")
 	flags.StringVar(&opts.tagAll, "tag-all", "", "Tag filter pattern to apply to all containers")
 	flags.StringSliceVar(&opts.tags, "tag", nil, "Tag filter container/pattern pairs")

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -53,7 +53,7 @@ func (opts *workloadReleaseOpts) Command() *cobra.Command {
 
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Workload namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
 	// Note: we cannot define a shorthand for --workload since it clashes with the shorthand of --watch
 	cmd.Flags().StringSliceVarP(&opts.workloads, "workload", "", []string{}, "List of workloads to release <namespace>:<kind>/<name>")
 	cmd.Flags().BoolVar(&opts.allWorkloads, "all", false, "Release all workloads")

--- a/cmd/fluxctl/unlock_cmd.go
+++ b/cmd/fluxctl/unlock_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadUnlockOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Controller namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Controller namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Controller to unlock")
 
 	// Deprecated


### PR DESCRIPTION
By looking at the configured namespace in the active context of the
resolved config, if none is found we return the given `defaultNamespace`.

Fixes #1877