### PR TITLE
Update contact info in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The Flux developers use a mailing list to discuss development as well.
 Simply subscribe to [flux-dev on Google
 Groups](https://groups.google.com/forum/#!forum/flux-dev) to join the
 conversation (this will also add an invitation to your Google calendar
-for our [Flux meeting](https://github.com/weaveworks/flux/wiki/Meeting)).
+for our [Flux meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARDeh6b70B0/edit#)).
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ contribution. No action from you is required, but it's a good idea to see the
 ## Communications
 
 The project uses Slack: To join the conversation, simply join the
-[Weave community](https://slack.weave.works/) Slack workspace and use the
-[#flux](https://weave-community.slack.com/messages/flux/) channel.
+[CNCF](https://slack.cncf.io/) Slack workspace and use the
+[#flux](https://cloud-native.slack.com/messages/flux/) channel.
 
 The Flux developers use a mailing list to discuss development as well.
 Simply subscribe to [flux-dev on Google

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flux
 
-> **Notice** Flux is moving house! Please see https://github.com/weaveworks/flux/wiki/MoveToFluxCD
+> **Notice** Flux has moved house! Please see https://github.com/weaveworks/flux/wiki/MoveToFluxCD
 
 We believe in GitOps:
 
@@ -99,7 +99,7 @@ Get started by browsing through the documentation below:
 
 - Background about Flux
   - [Introduction to Flux](/site/introduction.md)
-  - [FAQ](/site/faq.md) and [frequently encountered issues](https://github.com/weaveworks/flux/labels/FAQ)
+  - [FAQ](/site/faq.md) and [frequently encountered issues](https://github.com/fluxcd/flux/labels/FAQ)
   - [How it works](/site/how-it-works.md)
   - [Considerations regarding installing Flux](/site/installing.md)
   - [Flux <-> Helm integration](/site/helm-integration.md)
@@ -111,7 +111,7 @@ Get started by browsing through the documentation below:
   - [Using fluxctl to control Flux](/site/fluxctl.md)
   - [Helm Operator](/site/helm-operator.md)
   - [Troubleshooting](/site/troubleshooting.md)
-  - [Frequently encountered issues](https://github.com/weaveworks/flux/labels/FAQ)
+  - [Frequently encountered issues](https://github.com/fluxcd/flux/labels/FAQ)
   - [Upgrading to Flux v1](/site/upgrading-to-1.0.md)
 
 ### Integrations
@@ -145,14 +145,12 @@ be interested in the following:
 
 If you have any questions about Flux and continuous delivery:
 
-- Read [the Flux docs](https://github.com/weaveworks/flux/tree/master/site).
-- Invite yourself to the <a href="https://slack.weave.works/" target="_blank">Weave community</a>
-  slack and ask a question on the [#flux](https://weave-community.slack.com/messages/flux/)
+- Read [the Flux docs](https://github.com/fluxcd/flux/tree/master/site).
+- Invite yourself to the <a href="https://slack.cncf.io" target="_blank">CNCF community</a>
+  slack and ask a question on the [#flux](https://cloud-native.slack.com/messages/flux/)
   channel.
 - To be part of the conversation about Flux's development, join the
   [flux-dev mailing list](https://groups.google.com/forum/#!forum/flux-dev).
-- Join the [Weave User Group](https://www.meetup.com/pro/Weave/) and get
-  invited to online talks, hands-on training and meetups in your area.
-- [File an issue.](https://github.com/weaveworks/flux/issues/new)
+- [File an issue.](https://github.com/fluxcd/flux/issues/new)
 
 Your feedback is always welcome!

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ a few popular ones you might want to check out:
 We welcome all kinds of contributions to Flux, be it code, issues you found,
 documentation, external tools, help and support or anything else really.
 
+The Flux project adheres to the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
 Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by contacting a *Flux* project maintainer, or Alexis
-Richardson `<alexis@weave.works>`. Please refer to our [code of
-conduct](CODE_OF_CONDUCT.md) as well.
+may be reported by contacting a *Flux* project maintainer, or the CNCF
+mediator, Mishi Choudhary <mishi@linux.com>.
 
 To familiarise yourself with the project and how things work, you might
 be interested in the following:

--- a/site/upgrading-to-1.0.md
+++ b/site/upgrading-to-1.0.md
@@ -193,9 +193,3 @@ create those as resources.
 
 If that’s the case, you will need to remove the manifests from git
 before running Flux v1.
-
-### Something else went wrong
-
-You can reach Weaveworks developers in our community Slack --
-https://weaveworks.github.io/community-slack/ -- where we will be able
-to help.


### PR DESCRIPTION
This updates _most_ contact info and other links to point to the new repo or new Slack channel.

TODO

 - [ ] Get a replacement contact email for CoC