### PR TITLE
Let a named cluster role be used in chart

### DIFF
--- a/chart/flux/templates/_helpers.tpl
+++ b/chart/flux/templates/_helpers.tpl
@@ -43,6 +43,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the name of the cluster role to use
+*/}}
+{{- define "flux.clusterRoleName" -}}
+{{- if .Values.clusterRole.create -}}
+    {{ default (include "flux.fullname" .) .Values.clusterRole.name }}
+{{- else -}}
+    {{ default "default" .Values.clusterRole.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a custom repositories.yaml for Helm
 */}}
 {{- define "flux.customRepositories" -}}

--- a/chart/flux/templates/rbac.yaml
+++ b/chart/flux/templates/rbac.yaml
@@ -1,8 +1,9 @@
-{{- if and .Values.rbac.create .Values.clusterRole.create -}}
+{{- if .Values.rbac.create -}}
+{{if .Values.clusterRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "flux.fullname" . }}
+  name: {{ template "flux.clusterRoleName" . }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}
@@ -19,11 +20,13 @@ rules:
       - '*'
     verbs:
       - '*'
+{{- end -}}
+{{- if or .Values.clusterRole.create .Values.clusterRole.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "flux.fullname" . }}
+  name: {{ template "flux.clusterRoleName" . }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}
@@ -32,9 +35,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "flux.fullname" . }}
+  name: {{ template "flux.clusterRoleName" . }}
 subjects:
   - name: {{ template "flux.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+{{- end -}}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -101,10 +101,15 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed
-# and the kubeconfig default context will be set to that namespace
+# If create is `false` and no name is given, Flux and the Helm
+# Operator will be restricted to the namespace where they are
+# deployed, and the kubeconfig default context will be set to that
+# namespace.
 clusterRole:
   create: true
+  # The name of a cluster role to bind to; if not set and create is
+  # true, a name based on fullname is generated
+  name:
 
 resources:
   requests:


### PR DESCRIPTION
If you are stamping the Helm chart into a cluster a few times, it's
good to be able to refer to a single cluster role, rather than
creating one for each stamping.

This commit lets you supply a name for the cluster role to refer to;
to refer to an existing cluster role rather than creating one, use

    --set clusterRole.create=false --set clusterRole.name=pre-existing
