### PR TITLE
Let people supply Tiller hostname/IP to chart

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -134,7 +134,12 @@ spec:
         {{- else if .Values.helmOperator.allowNamespace }}
         - --allow-namespace={{ .Values.helmOperator.allowNamespace }}
         {{- end }}
+        {{- if .Values.helmOperator.tillerHost }}
+        - --tiller-ip={{ .Values.helmOperator.tillerHost }}
+        - --tiller-port={{ .Values.helmOperator.tillerPort }}
+        {{- else }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
+        {{- end }}
         {{- if .Values.helmOperator.tls.enable }}
         - --tiller-tls-enable={{ .Values.helmOperator.tls.enable }}
         - --tiller-tls-key-path=/etc/fluxd/helm/{{ .Values.helmOperator.tls.keyFile }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -35,7 +35,15 @@ helmOperator:
   chartsSyncInterval: "3m"
   # (Experimental) amount of workers processing releases
   workers:
+
   # Tiller settings
+
+  # If a hostname or IP is given here, that will be combined with the
+  # tillerPort and used for connecting to Tiller. Otherwise, the
+  # cluster-ip of the `tiller-deploy` service in .tillerNamespace is
+  # looked up.
+  tillerHost:
+  tillerPort: 44134
   tillerNamespace: kube-system
   tls:
     secretName: "helm-client-certs"


### PR DESCRIPTION
It's possible to tell the Helm operator to use a hostname or IP
address and port, but this isn't exposed in the chart.

This commit adds chart parameters for the Tiller host and IP. In
theory this would let you point at a Tiller listening on localhost --
but since the chart doesn't also include Tiller in the pod, it's not
quite enough.
