### PR TITLE
Mock `getKubeConfigContextNamespace` in tests

### DIFF
--- a/cmd/fluxctl/main_test.go
+++ b/cmd/fluxctl/main_test.go
@@ -65,6 +65,7 @@ func (t *genericMockRoundTripper) calledURL(method string) (u *url.URL) {
 func testArgs(t *testing.T, args []string, shouldErr bool, errMsg string) *genericMockRoundTripper {
 	svc := newMockService()
 	releaseClient := newWorkloadRelease(mockServiceOpts(svc))
+	getKubeConfigContextNamespace = func(s string) string { return s }
 
 	// Run fluxctl release
 	cmd := releaseClient.Command()

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -57,7 +57,7 @@ func TestReleaseCommand_CLIConversion(t *testing.T) {
 			t.Fatal("Failed to decode spec")
 		}
 		if !reflect.DeepEqual(v.expectedSpec, actualSpec.Spec) {
-			t.Fatalf("Expected %#v but got %#v", v.expectedSpec, actualSpec)
+			t.Fatalf("Expected %#v but got %#v", v.expectedSpec, actualSpec.Spec)
 		}
 
 		// Check that GetRelease was polled for status


### PR DESCRIPTION
To prevent an active kube config context on e.g. a local development
machine from interfering with the test results. #2255 follow up.