### PR TITLE
fixing prometheus scrape annotation

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
       {{- if .Values.prometheus.enabled }}
-        prometheus.io.scrape: "true"
+        prometheus.io/scrape: "true"
       {{- end }}
       {{- if .Values.annotations }}
       {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       annotations:
       {{- if .Values.prometheus.enabled }}
-        prometheus.io.scrape: "true"
+        prometheus.io/scrape: "true"
       {{- end }}
       {{- if .Values.helmOperator.annotations }}
       {{- .Values.helmOperator.annotations | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/cluster/kubernetes/policies_test.go
+++ b/cluster/kubernetes/policies_test.go
@@ -22,8 +22,8 @@ func TestUpdatePolicies(t *testing.T) {
 	}{
 		{
 			name: "adding annotation with others existing",
-			in:   []string{"prometheus.io.scrape", "'false'"},
-			out:  []string{"prometheus.io.scrape", "'false'", "flux.weave.works/automated", "'true'"},
+			in:   []string{"prometheus.io/scrape", "'false'"},
+			out:  []string{"prometheus.io/scrape", "'false'", "flux.weave.works/automated", "'true'"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.Automated: "true"},
 			},
@@ -38,8 +38,8 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "adding annotation when already has annotation and others",
-			in:   []string{"flux.weave.works/automated", "'true'", "prometheus.io.scrape", "'false'"},
-			out:  []string{"flux.weave.works/automated", "'true'", "prometheus.io.scrape", "'false'"},
+			in:   []string{"flux.weave.works/automated", "'true'", "prometheus.io/scrape", "'false'"},
+			out:  []string{"flux.weave.works/automated", "'true'", "prometheus.io/scrape", "'false'"},
 			update: resource.PolicyUpdate{
 				Add: policy.Set{policy.Automated: "true"},
 			},
@@ -54,8 +54,8 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "add and remove different annotations at the same time",
-			in:   []string{"flux.weave.works/automated", "'true'", "prometheus.io.scrape", "'false'"},
-			out:  []string{"prometheus.io.scrape", "'false'", "flux.weave.works/locked", "'true'"},
+			in:   []string{"flux.weave.works/automated", "'true'", "prometheus.io/scrape", "'false'"},
+			out:  []string{"prometheus.io/scrape", "'false'", "flux.weave.works/locked", "'true'"},
 			update: resource.PolicyUpdate{
 				Add:    policy.Set{policy.Locked: "true"},
 				Remove: policy.Set{policy.Automated: "true"},
@@ -72,8 +72,8 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "remove annotation with others existing",
-			in:   []string{"flux.weave.works/automated", "true", "prometheus.io.scrape", "false"},
-			out:  []string{"prometheus.io.scrape", "false"},
+			in:   []string{"flux.weave.works/automated", "true", "prometheus.io/scrape", "false"},
+			out:  []string{"prometheus.io/scrape", "false"},
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.Automated: "true"},
 			},
@@ -96,8 +96,8 @@ func TestUpdatePolicies(t *testing.T) {
 		},
 		{
 			name: "remove annotation with only others",
-			in:   []string{"prometheus.io.scrape", "false"},
-			out:  []string{"prometheus.io.scrape", "false"},
+			in:   []string{"prometheus.io/scrape", "false"},
+			out:  []string{"prometheus.io/scrape", "false"},
 			update: resource.PolicyUpdate{
 				Remove: policy.Set{policy.Automated: "true"},
 			},

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -471,7 +471,7 @@ spec:
       labels:
         name: authfe
       annotations:
-        prometheus.io.port: "8080"
+        prometheus.io/port: "8080"
     spec:
       # blank comment spacers in the following
       containers:
@@ -522,7 +522,7 @@ spec:
       labels:
         name: authfe
       annotations:
-        prometheus.io.port: "8080"
+        prometheus.io/port: "8080"
     spec:
       # blank comment spacers in the following
       containers:

--- a/deploy-helm/weave-cloud-helm-operator-deployment.yaml
+++ b/deploy-helm/weave-cloud-helm-operator-deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: flux-helm-operator
     spec:

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.port: "3031" # tell prometheus to scrape /metrics endpoint's port.
+        prometheus.io/port: "3031" # tell prometheus to scrape /metrics endpoint's port.
       labels:
         name: flux
     spec:


### PR DESCRIPTION
Fixing prometheus scrape annotation .  Currently Azure prometheus agent data collection is not working unless we add a custom annotation / use service end point. 

Slack conversation : https://weave-community.slack.com/archives/C4U5ATZ9S/p1563786967009700?thread_ts=1563785856.008800&cid=C4U5ATZ9S 