### PR TITLE
Enhance Git proxy support

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -2,7 +2,7 @@ FROM alpine:3.9
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg gawk
+RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg gawk socat
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing git-secret
 
 # Add git hosts to known hosts file so we can use

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -2,7 +2,7 @@ FROM alpine:3.9
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0'
+RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' socat
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh

--- a/git/operations.go
+++ b/git/operations.go
@@ -27,7 +27,7 @@ var exemptedTraceCommands = []string{
 // Env vars that are allowed to be inherited from the OS
 var allowedEnvVars = []string{
 	// these are for people using (no) proxies
-	"http_proxy", "https_proxy", "no_proxy",
+	"http_proxy", "https_proxy", "no_proxy", "GIT_PROXY_COMMAND",
 	// these are needed for GPG to find its files
 	"HOME", "GNUPGHOME",
 	// these for the git-secrets helper


### PR DESCRIPTION
_For our beloved enterprise users._

By adding `socat` to the Flux and Helm operator image and whitelisting `GIT_PROXY_COMMAND` inheritance.

Ref: https://gitolite.com/git-over-proxy.html

Fixes #2179 