### PR TITLE
Rename `--registry-poll-interval`

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -463,7 +463,7 @@ func (d *Daemon) updatePolicies(spec update.Spec, updates resource.PolicyUpdates
 			return result, err
 		}
 		if anythingAutomated {
-			d.AskForImagePoll()
+			d.AskForAutomatedWorkloadImageUpdates()
 		}
 
 		var err error

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -13,8 +13,8 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-func (d *Daemon) pollForNewImages(logger log.Logger) {
-	logger.Log("msg", "polling images")
+func (d *Daemon) pollForNewAutomatedWorkloadImages(logger log.Logger) {
+	logger.Log("msg", "polling for new images for automated workloads")
 
 	ctx := context.Background()
 

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -68,12 +68,13 @@ fluxd requires setup and offers customization though a multitude of flags.
 | **syncing:** control over how config is applied to the cluster
 | --sync-interval                                  | `5m`                               | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs
 | --sync-garbage-collection                        | `false`                            | experimental: when set, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](./garbagecollection.md))
+| **automation (of image updates):**
+| --automation-interval                            | `5m`                               | period at which to check for image updates for automated workloads
 | **registry cache:** (none of these need overriding, usually)
 | --memcached-hostname                             | `memcached`                        | hostname for memcached service to use for caching image metadata
 | --memcached-timeout                              | `1s`                               | maximum time to wait before giving up on memcached requests
 | --memcached-service                              | `memcached`                        | SRV service used to discover memcache servers
 | --registry-cache-expiry                          | `1h`                               | Duration to keep cached registry tag info. Must be < 1 month.
-| --registry-poll-interval                         | `5m`                               | period at which to poll registry for new images
 | --registry-rps                                   | `200`                              | maximum registry requests per second per host
 | --registry-burst                                 | `125`                              | maximum number of warmer connections to remote and memcache
 | --registry-insecure-host                         | []                                 | registry hosts to use HTTP for (instead of HTTPS)

--- a/site/faq.md
+++ b/site/faq.md
@@ -196,7 +196,7 @@ See also
    by default.
 
 The latter default is quite conservative, so you can try lowering it
-(it's set with the flag `--registry-poll-interval`).
+(it's set with the flag `--automation-interval`).
 
 Please don't _increase_ the rate limiting numbers (`--registry-rps`
 and `--registry-burst`) -- it's possible to get blacklisted by image

--- a/test/flux-deploy-all.yaml
+++ b/test/flux-deploy-all.yaml
@@ -94,5 +94,5 @@ spec:
         - --git-url=ssh://docker@MINIKUBE_IP:/home/docker/flux.git
         - --git-branch=master
         # Tune up to make tests run quicker
-        - --registry-poll-interval=60s
+        - --automation-interval=60s
         - --git-poll-interval=60s


### PR DESCRIPTION
The flag `--registry-poll-interval` used to control how often fluxd
would scan image repos for new images, and consequently update any
automated workloads. This has not been true for some time: it now
just controls the second part, while images are scanned on a
different schedule. The name is a persistent source of confusion.

Therefore: introduce a new flag `--automation-interval`, and make
`--registry-poll-interval` a synonym so as not to break things
suddenly, and deprecate the latter so as to encourage people to
change it.

Fixes #2281 