### PR TITLE
Fix values merge in helm-operator

### DIFF
--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -488,9 +488,9 @@ func fhrResourceID(fhr flux_v1beta1.HelmRelease) resource.ID {
 	return resource.MakeID(fhr.Namespace, "HelmRelease", fhr.Name)
 }
 
-// Merges source and destination `chartutils.Values`, preferring values from the source Values
+// Merges source and destination map, preferring values from the source Values
 // This is slightly adapted from https://github.com/helm/helm/blob/2332b480c9cb70a0d8a85247992d6155fbe82416/cmd/helm/install.go#L359
-func mergeValues(dest, src chartutil.Values) chartutil.Values {
+func mergeValues(dest, src map[string]interface{}) map[string]interface{} {
 	for k, v := range src {
 		// If the key doesn't exist already, then just set the key to that value
 		if _, exists := dest[k]; !exists {

--- a/integrations/helm/release/release_test.go
+++ b/integrations/helm/release/release_test.go
@@ -1,0 +1,77 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	flux_v1beta1 "github.com/weaveworks/flux/integrations/apis/flux.weave.works/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/helm/pkg/chartutil"
+)
+
+func TestValues(t *testing.T) {
+	falseVal := false
+
+	chartValues, _ := chartutil.ReadValues([]byte(`image:
+  tag: 1.1.1
+valuesDict:
+  chart: true`))
+
+	client := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "release-configmap",
+				Namespace: "flux",
+			},
+			Data: map[string]string{
+				"values.yaml": `valuesDict:
+  configmap: true`,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "release-secret",
+				Namespace: "flux",
+			},
+			Data: map[string][]byte{
+				"values.yaml": []byte(`valuesDict:
+  secret: true`),
+			},
+		},
+	)
+
+	valuesFromSource := []flux_v1beta1.ValuesFromSource{
+		flux_v1beta1.ValuesFromSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "release-configmap",
+				},
+				Key:      "values.yaml",
+				Optional: &falseVal,
+			},
+			SecretKeyRef:      nil,
+			ExternalSourceRef: nil,
+			ChartFileRef:      nil,
+		},
+		flux_v1beta1.ValuesFromSource{
+			ConfigMapKeyRef: nil,
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "release-secret",
+				},
+				Key:      "values.yaml",
+				Optional: &falseVal,
+			},
+			ExternalSourceRef: nil,
+			ChartFileRef:      nil,
+		}}
+
+	values, err := Values(client.CoreV1(), "flux", "", valuesFromSource, chartValues)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.1.1", values["image"].(map[string]interface{})["tag"])
+	assert.NotNil(t, values["valuesDict"].(map[string]interface{})["chart"])
+	assert.NotNil(t, values["valuesDict"].(map[string]interface{})["configmap"])
+	assert.NotNil(t, values["valuesDict"].(map[string]interface{})["secret"])
+}


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
Fix values merge in helm-operator.


Values merges in `helm-operator` will overwrite instead of merge a dict that has it's keys
defined in more than two sources (e.g : Values and multiple ValuesFrom).

This happens because when merging, https://github.com/fluxcd/flux/blob/6077df2f010a107669a44244536f7fbf65eaa3d7/integrations/helm/release/release.go#L507-L514
first iteration makes `dest[k]` a `chartutil.Values` and then at the next iteration will see `isMap` evaluate to False, overwriting instead of merging the two maps.

```
type Values map[string]interface{}

func main() {
    var v Values
    _, ok := interface{}(v).(map[string]interface{})
    fmt.Print(ok) // ok is false
}
```


I wrote a unit test that feed Values from a HelmRelease, a Configmap and a
Secret to make sure it fails, then changed `mergValues` signature to make it pass.

```
go test -v ./integrations/helm/release/
=== RUN   TestValues
--- FAIL: TestValues (0.00s)
    release_test.go:75:
        	Error Trace:	release_test.go:75
        	Error:      	Expected value not to be nil.
        	Test:       	TestValues
    release_test.go:76:
        	Error Trace:	release_test.go:76
        	Error:      	Expected value not to be nil.
        	Test:       	TestValues
FAIL
FAIL	github.com/weaveworks/flux/integrations/helm/release	0.498s
```

After the signature change :
```
go test -v ./integrations/helm/release/
=== RUN   TestValues
--- PASS: TestValues (0.00s)
PASS
ok  	github.com/weaveworks/flux/integrations/helm/release	0.242s
```

Fixes #1696.