### PR TITLE
Build: tweak killall to silence error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             # networking related issues, and thus holding on to
             # `/var/lib/apt/lists/lock`.
             # https://support.circleci.com/hc/en-us/articles/360021256633-Apt-Get-Update-Is-Slow-Or-Locked
-            sudo killall apt-get
+            sudo killall apt-get || true
 
             sudo apt-get update
             sudo apt-get install -y git rng-tools memcached


### PR DESCRIPTION
As we want to proceed if there is nothing to kill, given that our
goal is to have no apt-get processes running.

Sequel to #2301