### PR TITLE
Change go.mod import path to reflect the repo change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/weaveworks/flux
+module github.com/fluxcd/flux
 
 go 1.12
 


### PR DESCRIPTION
Otherwise, you can't vendor flux with Go modules properly.
Error message:

```
$ go mod tidy
go: github.com/fluxcd/flux@v0.0.0-20190729160321-c687c1fa3204: parsing go.mod: unexpected module path "github.com/weaveworks/flux"
go: finding golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7
go: error loading module requirements
```