### PR TITLE
Publish Flux chart to GitHub Pages with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,19 +27,21 @@ jobs:
           name: Publish chart
           command: |
             if [[ -z $CIRCLE_TAG ]]; then
-              echo "Not a release! Skip chart publish";
-              exit;
+              echo "Not a release! Skip chart publish"
+              exit
             fi
-            REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/flux.git"
-            git config user.email fluxcdbot@users.noreply.github.com
-            git config user.name fluxcdbot
-            git remote set-url origin ${REPOSITORY}
-            git checkout gh-pages-test
-            mv $HOME/chart/*.tgz .
-            helm repo index . --url https://fluxcd.github.io/flux
-            git add .
-            git commit -m "Publish Helm chart"
-            git push origin gh-pages-test
+            if echo "${CIRCLE_TAG}" | grep -Eq "^[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
+              REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/flux.git"
+              git config user.email fluxcdbot@users.noreply.github.com
+              git config user.name fluxcdbot
+              git remote set-url origin ${REPOSITORY}
+              git checkout gh-pages
+              mv $HOME/chart/*.tgz .
+              helm repo index . --url https://fluxcd.github.io/flux
+              git add .
+              git commit -m "Publish Helm chart"
+              git push origin gh-pages
+            fi
   build:
     working_directory: /home/circleci/go/src/github.com/weaveworks/flux
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
       - run:
           name: Publish chart
           command: |
+            if [[ -z $CIRCLE_TAG ]]; then
+              echo "Not a release! Skip chart publish";
+              exit;
+            fi
             REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/flux.git"
             git config user.email fluxcdbot@users.noreply.github.com
             git config user.name fluxcdbot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,23 @@ jobs:
           command: |
             helm lint ./chart/flux
       - run:
-          name: Lint chart
-          command: |
-            helm lint ./chart/flux
-      - run:
           name: Package chart
           command: |
             mkdir $HOME/chart
             helm package ./chart/flux --destination $HOME/chart
-            ls $HOME/chart
+      - run:
+          name: Publish chart
+          command: |
+            REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/flux.git"
+            git config user.email fluxcdbot@users.noreply.github.com
+            git config user.name fluxcdbot
+            git remote set-url origin ${REPOSITORY}
+            git checkout gh-pages-test
+            mv $HOME/chart/*.tgz .
+            helm repo index . --url https://fluxcd.github.io/flux
+            git add .
+            git commit -m "Publish Helm chart"
+            git push origin gh-pages-test
   build:
     working_directory: /home/circleci/go/src/github.com/weaveworks/flux
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
           name: Lint chart
           command: |
             helm lint ./chart/flux
+      - run:
+          name: Lint chart
+          command: |
+            helm lint ./chart/flux
+      - run:
+          name: Package chart
+          command: |
+            mkdir $HOME/chart
+            helm package ./chart/flux --destination $HOME/chart
+            ls $HOME/chart
   build:
     working_directory: /home/circleci/go/src/github.com/weaveworks/flux
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,7 @@ jobs:
       - run:
           name: Publish chart
           command: |
-            if [[ -z $CIRCLE_TAG ]]; then
-              echo "Not a release! Skip chart publish"
-              exit
-            fi
-            if echo "${CIRCLE_TAG}" | grep -Eq "^[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
+            if echo "${CIRCLE_TAG}" | grep -Eq "chart-[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
               REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/flux.git"
               git config user.email fluxcdbot@users.noreply.github.com
               git config user.name fluxcdbot
@@ -41,6 +37,8 @@ jobs:
               git add .
               git commit -m "Publish Helm chart"
               git push origin gh-pages
+            else
+              echo "Not a chart release! Skip chart publish"
             fi
   build:
     working_directory: /home/circleci/go/src/github.com/weaveworks/flux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,23 @@
 version: 2
 jobs:
+  helm:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - run:
+          name: Install kubectl
+          command: sudo curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && sudo chmod +x /usr/local/bin/kubectl
+      - run:
+          name: Install helm
+          command: sudo curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.14.2-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /bin/helm && sudo rm -rf linux-amd64
+      - run:
+          name: Initialize helm
+          command:  helm init --client-only --kubeconfig=$HOME/.kube/kubeconfig
+      - run:
+          name: Lint chart
+          command: |
+            helm lint ./chart/flux
   build:
     working_directory: /home/circleci/go/src/github.com/weaveworks/flux
     machine:
@@ -119,6 +137,7 @@ workflows:
   version: 2
   build-and-push:
     jobs:
+      - helm
       - build:
           filters:
             tags:


### PR DESCRIPTION
Migrate Helm chart lint, package and deploy from GH Actions to CircleCI.

This was tested with gh-pages-test branch by removing the git tag filter from the publish step.
See https://github.com/fluxcd/flux/commit/d3267f1f45b602a27bd0e6c15557d8186086f8d7