### PR TITLE
Add manifest generation to helm chart.

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -186,6 +186,9 @@ spec:
           {{- if .Values.git.label }}
           - --git-label={{ .Values.git.label }}
           {{- end }}
+          {{- if .Values.git.manifestGeneration }}
+          - --manifest-generation=true
+          {{- end }}
           - --registry-poll-interval={{ .Values.registry.pollInterval }}
           - --registry-rps={{ .Values.registry.rps }}
           - --registry-burst={{ .Values.registry.burst }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -178,6 +178,8 @@ git:
     # data: |
     #   [credential "https://github.com"]
     #           username = foo
+  # Enables manifest generation. For an example see: https://github.com/weaveworks/flux-kustomize-example
+  manifestGeneration: false
 
 registry:
   # Period at which to check for updated images


### PR DESCRIPTION
To be able to use flux with kustomize, it needs to be started with
--manifest-generation, this was absent in the helm chart. This
PR adds this.