### PR TITLE
Reduce sorts done by ListImagesWithOptions

### DIFF
--- a/api/v6/container_test.go
+++ b/api/v6/container_test.go
@@ -7,7 +7,18 @@ import (
 
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
+	"github.com/weaveworks/flux/update"
 )
+
+type justSlice []image.Info
+
+func (j justSlice) Images() []image.Info {
+	return []image.Info(j)
+}
+
+func (j justSlice) SortedImages(p policy.Pattern) update.SortedImageInfos {
+	return update.SortImages(j.Images(), p)
+}
 
 func TestNewContainer(t *testing.T) {
 
@@ -127,7 +138,7 @@ func TestNewContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewContainer(tt.args.name, tt.args.images, tt.args.currentImage, tt.args.tagPattern, tt.args.fields)
+			got, err := NewContainer(tt.args.name, justSlice(tt.args.images), tt.args.currentImage, tt.args.tagPattern, tt.args.fields)
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
The PR as a whole is intended to address #2328 by reducing the number of sorts, since that was identified as a bottleneck there.

The API `ListImagesWithOptions` as called by Weave Cloud asks for pretty much all the fields, so the first commit here will not make a big difference -- there will still be one sort per container. It may avoid some allocation, and some calculation in other uses (i.e., when not called by Weave Cloud).

The second commit caches the result of sorting by timestamp, when that is done. It will be effective to the extent that
 - the same image is used in more than one container
 - containers are using tag filters that ordered the images by timestamp (i.e., everything but semver)

There are some modest improvements that could be made with more invasive changes. Possibly the biggest improvement would be to sort images (actually the image tags) when they are _fetched_, rather than when they are used, since the latter will usually outnumber the former by orders of magnitude.