### PR TITLE
Fix publishing to charts.fluxcd.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
               git config user.name fluxcdbot
               git remote set-url origin ${REPOSITORY}
               git checkout gh-pages
-              mv $HOME/chart/*.tgz .
+              cp $HOME/chart/*.tgz .
               helm repo index . --url https://fluxcd.github.io/flux
               git add .
               git commit -m "Publish Helm chart"


### PR DESCRIPTION
Use `cp` instead of `mv` to be able to publish the charts to both repos.