### PR TITLE
Omise is using Flux in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ container images and config changes are propagated to the cluster.
 - [karriere tutor GmbH](https://www.karrieretutor.de)
 - [loveholidays](https://www.loveholidays.com/)
 - [Mettle](https://mettle.co.uk)
+- [Omise](https://www.omise.co)
 - [Payout](https://payout.one)
 - [Qordoba](https://qordoba.com)
 - [Rungway](https://rungway.com)
@@ -69,7 +70,6 @@ container images and config changes are propagated to the cluster.
 - [Walmart Chile](https://www.walmartchile.cl)
 - [Weave Cloud](https://cloud.weave.works)
 - [Yusofleet](https://yusofleet.com)
-- [Omise](https://www.omise.co)
 
 If you too are using Flux in production; please submit a PR to add your organization to the list!
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ container images and config changes are propagated to the cluster.
 - [Walmart Chile](https://www.walmartchile.cl)
 - [Weave Cloud](https://cloud.weave.works)
 - [Yusofleet](https://yusofleet.com)
+- [Omise](https://www.omise.co)
 
 If you too are using Flux in production; please submit a PR to add your organization to the list!
 


### PR DESCRIPTION
Add Omise to the list of users of Flux in production
We're very happy on how it prevents (or reduces) the chance of devops manually applying changes to our K8 clusters and then being out of sync.
Also improves our cluster security. Only Flux can push! 👍 