### PR TITLE
Remove Go tarbal once Go is installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
             sudo rm -rf /usr/local/go
             sudo mv go /usr/local
             mkdir -p "$HOME/go/bin"
+            rm -rf go${GO_VERSION}.linux-amd64.tar.gz
             go version
       - run:
           name: Update packages and start Memcached


### PR DESCRIPTION
As before this change the state of the Git repository contained changes,
resulting in the prerelease image tags being suffixed with `-wip`.