### PR TITLE
Switch order of `test` and `check-generated`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
           keys:
             - go-mod-{{ checksum "go.mod" }}
             - go-mod-
-      - run: make check-generated
       - run: make test TEST_FLAGS="-race -tags integration -timeout 60s"
+      - run: make check-generated
       - run: make all
       - run: make e2e
       - run: make test-docs


### PR DESCRIPTION
As `test` modifies `go.mod` and `check-generated` restores it,
ultimately restoring the git state to a clean working tree.

This is a hotfix as `bin/helm/update_codegen.sh` has only a limited
lifetime left in this repository.

#2344 follow up.