### PR TITLE
Stop pushing Helm operator images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,16 +133,10 @@ jobs:
               docker tag "docker.io/fluxcd/flux:$(docker/image-tag)" "docker.io/weaveworks/flux-prerelease:$(docker/image-tag)"
               docker push "docker.io/weaveworks/flux-prerelease:$(docker/image-tag)"
 
-              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/weaveworks/helm-operator-prerelease:$(docker/image-tag)"
-              docker push "docker.io/weaveworks/helm-operator-prerelease:$(docker/image-tag)"
-
               # Push to fluxcd org
               echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
               docker tag "docker.io/fluxcd/flux:$(docker/image-tag)" "docker.io/fluxcd/flux-prerelease:$(docker/image-tag)"
               docker push "docker.io/fluxcd/flux-prerelease:$(docker/image-tag)"
-
-              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
-              docker push "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
             fi
       - deploy:
           name: Maybe push release image and upload binaries
@@ -159,18 +153,6 @@ jobs:
               # Push to fluxcd org
               echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
               docker push "docker.io/fluxcd/flux:${CIRCLE_TAG}"
-            fi
-            if echo "${CIRCLE_TAG}" | grep -Eq "helm-[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
-              RELEASE_TAG=$(echo "$CIRCLE_TAG" | cut -c 6-)
-
-              # Push to weaveworks org
-              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
-              docker tag "docker.io/fluxcd/helm-operator:${RELEASE_TAG}" "docker.io/weaveworks/helm-operator:${RELEASE_TAG}"
-              docker push "docker.io/weaveworks/helm-operator:${RELEASE_TAG}"
-
-              # Push to fluxcd org
-              echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
-              docker push "docker.io/fluxcd/helm-operator:${RELEASE_TAG}"
             fi
 
 workflows:


### PR DESCRIPTION
This commit has overlap with work done in #2329. We do however need
to disable the push of images before we actually remove the code, to
be able to safely switch to `master` in the `fluxcd/helm-operator`
repository. As otherwise the prerelease images will have builds from
mixed origins.