### PR TITLE
Add Kustomize, Helm and Flagger to docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,7 +43,8 @@ version.
 
 ## Integrations with other devops tools
 
-One final high-level feature is that Flux increases visibility of your
-application. Clear visibility of the state of a cluster is key for
-maintaining operational systems. Developers can be confident in their
-changes by observing a predictable series of deployment events.
+For configuration customization across environments and clusters, Flux comes with builtin support 
+for [Kustomize](references/fluxyaml-config-files.md) and [Helm](references/helm-operator-integration.md).
+
+For advanced deployment patterns like Canary releases, A/B testing and Blue/Green deployments,
+Flux can be used together with [Flagger](https://github.com/weaveworks/flagger).

--- a/docs/references/helm-operator-integration.md
+++ b/docs/references/helm-operator-integration.md
@@ -1,7 +1,7 @@
 # Integration with the Helm operator
 
 You can release charts to your cluster via "GitOps", by combining Flux
-and the Helm operator (also in [fluxcd/flux](https://github.com/fluxcd/flux)).
+and the [Helm operator](https://github.com/fluxcd/helm-operator).
 
 The essential mechanism is this: the declaration of a Helm release is
 represented by a custom resource, specifying the chart and its


### PR DESCRIPTION
This PR adds Kustomize, Helm and Flagger to the integrations with other devops tools docs.