### PR TITLE
Docs: fix link to chart/flux/README.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,7 +88,7 @@ reasons this can happen:
    both make sure this is the case.
  - When using images from ACR in AKS, the HostPath `/etc/kubernetes/azure.json`
    should be [mounted](https://kubernetes.io/docs/concepts/storage/volumes/) into the Flux Pod.
-   Set `registry.acr.enabled=True` in the [helm chart](https://github.com/fluxcd/flux/blob/master/chart/flux/README.md)
+   Set `registry.acr.enabled=True` in the [helm chart](https://github.com/fluxcd/flux/blob/master/chart/flux/README.md#)
    or alter the [Deployment](https://github.com/fluxcd/flux/blob/master/deploy/flux-deployment.yaml):
    ```yaml
     spec:

--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -86,7 +86,7 @@ In this next step you install Flux using `helm`. Simply
 
       When deploying from a private repo, the known_hosts of the git server needs
       to be configured into a kubernetes configmap so that `StrictHostKeyChecking` is respected.
-      See the [README of the chart](https://fluxcd/flux/blob/master/chart/flux/README.md#to-install-flux-with-the-helm-operator-and-a-private-git-repository)
+      See the [README of the chart](https://github.com/fluxcd/flux/blob/master/chart/flux/README.md#to-install-flux-with-the-helm-operator-and-a-private-git-repository)
       for further installation instructions in this case.
 
 Allow some time for all containers to get up and running. If you're

--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -6,7 +6,7 @@ any code changes for you.
 
 If you are looking for more generic notes for how to install Flux
 using Helm, we collected them [in the chart's
-README](https://github.com/fluxcd/flux/blob/master/chart/flux/README.md).
+README](https://github.com/fluxcd/flux/blob/master/chart/flux/README.md#).
 
 ## Prerequisites
 


### PR DESCRIPTION
I've found that links to `chart/flux/README.md` are broken when accessing from https://docs.fluxcd.io

The 3 broken links are:

1. https://docs.fluxcd.io/en/latest/tutorials/get-started-helm.html
links to `https://fluxcd/` and should link to `https://github.com/fluxcd`
2. https://docs.fluxcd.io/en/latest/tutorials/get-started-helm.html
renders without the `.md`
`
<a class="reference external" href="https://github.com/fluxcd/flux/blob/master/chart/flux/README">in the chart’s 
README</a>.</p>
`
3. https://docs.fluxcd.io/en/latest/troubleshooting.html 
renders without the `.md`
`
<a class="reference external" href="https://github.com/fluxcd/flux/blob/master/chart/flux/README">helm chart</a>
`

