### PR TITLE
fix snap build (go modules, go 1.12, etc.)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,11 +35,18 @@ parts:
         snapcraftctl set-version "$FLUX_TAG+$GIT_REV"
         snapcraftctl set-grade devel
       fi
-    plugin: go
-    go-importpath: github.com/weaveworks/flux
+    plugin: nil
+    override-build: |
+      export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
+      go build ./cmd/fluxctl
+    build-environment:
+      - GO111MODULE: 'on'
+      - CGO_ENABLED: '0'
     build-packages:
       - gcc
       - git
+    build-snaps:
+      - go/1.12/stable
     stage:
       - -bin/fluxd
       - -bin/helm-operator

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
     plugin: nil
     override-build: |
       export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
-      go build ./cmd/fluxctl
+      go build -o $GOBIN/fluxctl ./cmd/fluxctl
     build-environment:
       - GO111MODULE: 'on'
       - CGO_ENABLED: '0'


### PR DESCRIPTION
Not sure why this started to bite us just now, but I instructed the snapcraft build to use go1.12 and go modules.

Unfortunately, due to https://forum.snapcraft.io/t/go-modules/7265/7 I moved off the 'go' build plugin for now.