### PR TITLE
chart: add the ability to disable the memcached deployment

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -248,6 +248,8 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `registry.dockercfg.enabled`                      | `false`                                              | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file
 | `registry.dockercfg.secretName`                   | `None`                                               | Kubernetes secret with the docker config.json
 | `registry.dockercfg.configFileName`               | `/dockercfg/config.json`                             | Alternative path/name of the docker config.json
+| `memcached.enabled`                               | `true`                                               | Create a memcached deployment and service. When set to `false` you must set an external memcached service.
+| `memcached.hostnameOverride`                      | `None`                                               | Override the hostname to the memcached service. Useful when using memcached deployed separately from this chart.
 | `memcached.verbose`                               | `false`                                              | Enable request logging in memcached
 | `memcached.maxItemSize`                           | `5m`                                                 | Maximum size for one item
 | `memcached.maxMemory`                             | `128`                                                | Maximum memory to use, in megabytes

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -168,7 +168,7 @@ spec:
           {{end}}
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
-          - --memcached-hostname={{ template "flux.fullname" . }}-memcached
+          - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}
           {{- if .Values.memcached.createClusterIP }}
           - --memcached-service=

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.memcached.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,3 +78,4 @@ spec:
   selector:
     app: {{ template "flux.name" . }}-memcached
     release: {{ .Release.Name }}
+{{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -224,6 +224,8 @@ registry:
     configFileName: /dockercfg/config.json
 
 memcached:
+  enabled: true
+  hostnameOverride:
   repository: memcached
   tag: 1.5.15
   pullSecret:


### PR DESCRIPTION
In some cases it can be useful to deploy flux without memcached e.g. when not using the image scanning features or if you want to use an external memcached service deployed separately from the flux chart.
This change adds the ability to disable the memcached deployment in the helm chart and / or override the memcached hostname.