### PR TITLE
Fix portforward error check

### DIFF
--- a/cmd/fluxctl/portforward.go
+++ b/cmd/fluxctl/portforward.go
@@ -21,7 +21,7 @@ func tryPortforwards(ns string, selectors ...metav1.LabelSelector) (p *portforwa
 			return
 		}
 
-		if !strings.Contains(err.Error(), "Could not find pod for selector") {
+		if !strings.Contains(err.Error(), "Could not find running pod for selector") {
 			return
 		} else {
 			message = fmt.Sprintf("%s\n  %s", message, metav1.FormatLabelSelector(&selector))


### PR DESCRIPTION
We were not checking portforwarding errors properly, causing fluxctl to only test the first label selector provided, and in turn causing to fail selecting on `name={"flux", "fluxd", "weave-flux-agent"}` as intended by https://github.com/fluxcd/flux/blob/d18267b6bfb1ca485f13d04efdb8d4b41dc66393/cmd/fluxctl/root_cmd.go#L129