### PR TITLE
Release chart v0.14.0

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.14.0 (2019-08-22)
+
+### Improvements
+
+ - Updated Flux to `1.14.1`
+   [fluxcd/flux#2401](https://github.com/fluxcd/flux/pull/2401)
+ - Add the ability to disable memcached and set an external memcached service
+   [fluxcd/flux#2393](https://github.com/fluxcd/flux/pull/2393)
+
 ## 0.13.0 (2019-08-21)
 
 ### Improvements

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.14.1"
-version: 0.13.0
+version: 0.14.0
 kubeVersion: ">=1.9.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control


### PR DESCRIPTION
 - Updated Flux to `1.14.1`
   [fluxcd/flux#2401](https://github.com/fluxcd/flux/pull/2401)
 - Add the ability to disable memcached and set an external memcached service
   [fluxcd/flux#2393](https://github.com/fluxcd/flux/pull/2393)