### PR TITLE
Fix crash on listing helm releases if v1 release exists

### DIFF
--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -509,8 +509,8 @@ func (hr *helmReleaseKind) getWorkloads(ctx context.Context, c *Cluster, namespa
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	var names map[string]bool
-	var workloads []workload
+	names := make(map[string]bool, 0)
+	workloads := make([]workload, 0)
 	if helmReleases, err := c.client.HelmV1().HelmReleases(namespace).List(meta_v1.ListOptions{}); err == nil {
 		for i, _ := range helmReleases.Items {
 			workload := makeHelmReleaseStableWorkload(&helmReleases.Items[i])


### PR DESCRIPTION
Initialize two variable that weren't initalized before and resulted in a crash when a v1 helm release resource existed in the cluster.


Crash log (before the fix):

```
goroutine 72 [running]:
github.com/weaveworks/flux/cluster/kubernetes.(*helmReleaseKind).getWorkloads(0x286b410, 0x1aeee80, 0xc00009c058, 0xc000236700, 0xc000571200, 0xd, 0x0, 0x0, 0x0, 0x0, ...)
	/home/circleci/go/src/github.com/weaveworks/flux/cluster/kubernetes/resourcekinds.go:518 +0x165
github.com/weaveworks/flux/cluster/kubernetes.(*Cluster).ImagesToFetch(0xc000236700, 0x0)
	/home/circleci/go/src/github.com/weaveworks/flux/cluster/kubernetes/images.go:137 +0x76f
github.com/weaveworks/flux/registry.ImageCredsWithAWSAuth.func5(0xdf8475800)
	/home/circleci/go/src/github.com/weaveworks/flux/registry/aws.go:211 +0x8d
github.com/weaveworks/flux/registry/cache.(*Warmer).Loop(0xc000079e40, 0x1ab9120, 0xc00021c330, 0xc0000865a0, 0xc000044de0, 0xc0005892c0)
	/home/circleci/go/src/github.com/weaveworks/flux/registry/cache/warming.go:83 +0x90
created by main.main
	/home/circleci/go/src/github.com/weaveworks/flux/cmd/fluxd/main.go:724 +0x635f
```

This looks like the code will need more tests at some point, but given that the current implementation is completely broken if a v1 helm release exists, this simple fix is probably better than nothing for now.
