### PR TITLE
Fix crash on listing helm releases

### DIFF
--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -509,7 +509,7 @@ func (hr *helmReleaseKind) getWorkloads(ctx context.Context, c *Cluster, namespa
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	names := make(map[string]bool, 0)
+	names := make(map[string]bool)
 	workloads := make([]workload, 0)
 	if helmReleases, err := c.client.HelmV1().HelmReleases(namespace).List(meta_v1.ListOptions{}); err == nil {
 		for i, _ := range helmReleases.Items {


### PR DESCRIPTION
Hi!

As mentioned in https://github.com/fluxcd/flux/issues/2396#issuecomment-524374196, I think `names` needs to be initialized without the size argument to not cause a panic...

```
ts=2019-08-23T15:32:22.599468923Z caller=main.go:232 version=1.14.1
...
ts=2019-08-23T15:32:22.639077625Z caller=images.go:27 component=sync-loop msg="no automated workloads"
panic: assignment to entry in nil map
 goroutine 66 [running]:
github.com/weaveworks/flux/cluster/kubernetes.(*helmReleaseKind).getWorkloads(0x286b410, 0x1aeee80, 0xc000044070, 0xc0000ec300, 0xc0001018e4, 0x9, 0x0, 0x0, 0x0, 0x0, ...)
	/home/circleci/go/src/github.com/weaveworks/flux/cluster/kubernetes/resourcekinds.go:518 +0x165
github.com/weaveworks/flux/cluster/kubernetes.(*Cluster).ImagesToFetch(0xc0000ec300, 0x0)
	/home/circleci/go/src/github.com/weaveworks/flux/cluster/kubernetes/images.go:137 +0x76f
github.com/weaveworks/flux/registry.ImageCredsWithAWSAuth.func5(0xdf8475800)
	/home/circleci/go/src/github.com/weaveworks/flux/registry/aws.go:211 +0x8d
github.com/weaveworks/flux/registry/cache.(*Warmer).Loop(0xc0004d8b80, 0x1ab9120, 0xc0005f3fb0, 0xc0000865a0, 0xc000101010, 0xc0001187d0)
	/home/circleci/go/src/github.com/weaveworks/flux/registry/cache/warming.go:83 +0x90
created by main.main
	/home/circleci/go/src/github.com/weaveworks/flux/cmd/fluxd/main.go:724 +0x635f
```