### PR TITLE
Fix the resolving of a single v1 HelmRelease

### DIFF
--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -488,7 +488,7 @@ func (hr *helmReleaseKind) getWorkload(ctx context.Context, c *Cluster, namespac
 	if err := ctx.Err(); err != nil {
 		return workload{}, err
 	}
-	if helmRelease, err := c.client.HelmV1().HelmReleases(name).Get(name, meta_v1.GetOptions{}); err == nil {
+	if helmRelease, err := c.client.HelmV1().HelmReleases(namespace).Get(name, meta_v1.GetOptions{}); err == nil {
 		return makeHelmReleaseStableWorkload(helmRelease), err
 	}
 	helmRelease, err := c.client.FluxV1beta1().HelmReleases(namespace).Get(name, meta_v1.GetOptions{})


### PR DESCRIPTION
Due to a mistake the name of the resource was used as a namespace
argument, as a result several functionalities relying on this method
did no longer work as it was unable to find the given workload (e.g.
automatic image updates and fluxctl workload selector flags). Passing
along the namespace (as intended) resolves all this.