### PR TITLE
Update driving-flux.md

### DIFF
--- a/docs/tutorials/driving-flux.md
+++ b/docs/tutorials/driving-flux.md
@@ -21,7 +21,7 @@ fluxctl install \
 --git-user=${GHUSER} \
 --git-email=${GHUSER}@users.noreply.github.com \
 --git-url=git@github.com:${GHUSER}/flux-get-started \
---git-paths=namespaces,workloads \
+--git-path=namespaces,workloads \
 --namespace=flux | kubectl apply -f -
 ```
 


### PR DESCRIPTION
Renamed the parameter git-paths in version 1.14.1 to git-path

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
