### PR TITLE
update gitSecret feature to handle git.Export

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -613,7 +613,6 @@ func main() {
 		SigningKey:  *gitSigningKey,
 		SetAuthor:   *gitSetAuthor,
 		SkipMessage: *gitSkipMessage,
-		GitSecret:   *gitSecret,
 	}
 
 	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout), git.Branch(*gitBranch), git.IsReadOnly(*gitReadonly))
@@ -694,6 +693,7 @@ func main() {
 		JobStatusCache:            &job.StatusCache{Size: 100},
 		Logger:                    log.With(logger, "component", "daemon"),
 		ManifestGenerationEnabled: *manifestGeneration,
+		GitSecretEnabled:          *gitSecret,
 		LoopVars: &daemon.LoopVars{
 			SyncInterval:        *syncInterval,
 			SyncState:           syncProvider,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -660,6 +660,11 @@ func (d *Daemon) WithWorkingClone(ctx context.Context, fn func(*git.Checkout) er
 		return err
 	}
 	defer co.Clean()
+	if d.GitSecretEnabled {
+		if err := co.SecretUnseal(ctx); err != nil {
+			return err
+		}
+	}
 	return fn(co)
 }
 
@@ -671,11 +676,16 @@ func (d *Daemon) WithReadonlyClone(ctx context.Context, fn func(*git.Export) err
 	if err != nil {
 		return err
 	}
-	co, err := d.Repo.Export(ctx, head, d.GitSecretEnabled)
+	co, err := d.Repo.Export(ctx, head)
 	if err != nil {
 		return err
 	}
 	defer co.Clean()
+	if d.GitSecretEnabled {
+		if err := co.SecretUnseal(ctx); err != nil {
+			return err
+		}
+	}
 	return fn(co)
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -55,6 +55,7 @@ type Daemon struct {
 	EventWriter               event.EventWriter
 	Logger                    log.Logger
 	ManifestGenerationEnabled bool
+	GitSecretEnabled          bool
 	// bookkeeping
 	*LoopVars
 }
@@ -670,7 +671,7 @@ func (d *Daemon) WithReadonlyClone(ctx context.Context, fn func(*git.Export) err
 	if err != nil {
 		return err
 	}
-	co, err := d.Repo.Export(ctx, head)
+	co, err := d.Repo.Export(ctx, head, d.GitSecretEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -42,7 +42,7 @@ type changeSet struct {
 func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, ratchet revisionRatchet) error {
 	// Make a read-only clone used for this sync
 	ctxt, cancel := context.WithTimeout(ctx, d.GitTimeout)
-	working, err := d.Repo.Export(ctxt, newRevision)
+	working, err := d.Repo.Export(ctxt, newRevision, d.GitSecretEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/git/export.go
+++ b/pkg/git/export.go
@@ -21,23 +21,28 @@ func (e *Export) Clean() {
 }
 
 // Export creates a minimal clone of the repo, at the ref given.
-func (r *Repo) Export(ctx context.Context, ref string, gitSecretEnabled bool) (*Export, error) {
+func (r *Repo) Export(ctx context.Context, ref string) (*Export, error) {
 	dir, err := r.workingClone(ctx, "")
 	if err != nil {
 		return nil, err
 	}
-	if err = checkout(ctx, dir, ref, gitSecretEnabled); err != nil {
+	if err = checkout(ctx, dir, ref); err != nil {
 		return nil, err
 	}
 	return &Export{dir}, nil
 }
 
+// SecretUnseal unseals git secrets in the clone.
+func (e *Export) SecretUnseal(ctx context.Context) error {
+	return secretUnseal(ctx, e.Dir())
+}
+
 // ChangedFiles does a git diff listing changed files
-func (c *Export) ChangedFiles(ctx context.Context, sinceRef string, paths []string) ([]string, error) {
-	list, err := changed(ctx, c.Dir(), sinceRef, paths)
+func (e *Export) ChangedFiles(ctx context.Context, sinceRef string, paths []string) ([]string, error) {
+	list, err := changed(ctx, e.Dir(), sinceRef, paths)
 	if err == nil {
 		for i, file := range list {
-			list[i] = filepath.Join(c.Dir(), file)
+			list[i] = filepath.Join(e.Dir(), file)
 		}
 	}
 	return list, err

--- a/pkg/git/export.go
+++ b/pkg/git/export.go
@@ -21,12 +21,12 @@ func (e *Export) Clean() {
 }
 
 // Export creates a minimal clone of the repo, at the ref given.
-func (r *Repo) Export(ctx context.Context, ref string) (*Export, error) {
+func (r *Repo) Export(ctx context.Context, ref string, gitSecretEnabled bool) (*Export, error) {
 	dir, err := r.workingClone(ctx, "")
 	if err != nil {
 		return nil, err
 	}
-	if err = checkout(ctx, dir, ref); err != nil {
+	if err = checkout(ctx, dir, ref, gitSecretEnabled); err != nil {
 		return nil, err
 	}
 	return &Export{dir}, nil

--- a/pkg/git/export_test.go
+++ b/pkg/git/export_test.go
@@ -29,7 +29,7 @@ func TestExportAtRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	export, err := repo.Export(ctx, headMinusOne, false)
+	export, err := repo.Export(ctx, headMinusOne)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/git/export_test.go
+++ b/pkg/git/export_test.go
@@ -29,7 +29,7 @@ func TestExportAtRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	export, err := repo.Export(ctx, headMinusOne)
+	export, err := repo.Export(ctx, headMinusOne, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -79,9 +79,20 @@ func mirror(ctx context.Context, workingDir, repoURL string) (path string, err e
 	return repoPath, nil
 }
 
-func checkout(ctx context.Context, workingDir, ref string) error {
+func checkout(ctx context.Context, workingDir, ref string, gitSecretEnabled bool) error {
 	args := []string{"checkout", ref, "--"}
-	return execGitCmd(ctx, args, gitCmdConfig{dir: workingDir})
+
+	err := execGitCmd(ctx, args, gitCmdConfig{dir: workingDir})
+	if err != nil {
+		return err
+	}
+
+	if gitSecretEnabled {
+		if err := secretUnseal(ctx, workingDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func add(ctx context.Context, workingDir, path string) error {

--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -79,18 +79,11 @@ func mirror(ctx context.Context, workingDir, repoURL string) (path string, err e
 	return repoPath, nil
 }
 
-func checkout(ctx context.Context, workingDir, ref string, gitSecretEnabled bool) error {
+func checkout(ctx context.Context, workingDir, ref string) error {
 	args := []string{"checkout", ref, "--"}
-
 	err := execGitCmd(ctx, args, gitCmdConfig{dir: workingDir})
 	if err != nil {
 		return err
-	}
-
-	if gitSecretEnabled {
-		if err := secretUnseal(ctx, workingDir); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/git/working.go
+++ b/pkg/git/working.go
@@ -22,7 +22,6 @@ type Config struct {
 	SigningKey  string
 	SetAuthor   bool
 	SkipMessage string
-	GitSecret   bool
 }
 
 // Checkout is a local working clone of the remote repo. It is
@@ -189,7 +188,7 @@ func (c *Checkout) MoveTagAndPush(ctx context.Context, tagAction TagAction) erro
 }
 
 func (c *Checkout) Checkout(ctx context.Context, rev string) error {
-	return checkout(ctx, c.Dir(), rev, false)
+	return checkout(ctx, c.Dir(), rev)
 }
 
 func (c *Checkout) Add(ctx context.Context, path string) error {

--- a/pkg/git/working.go
+++ b/pkg/git/working.go
@@ -101,12 +101,6 @@ func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
 	}
 	r.mu.RUnlock()
 
-	if conf.GitSecret {
-		if err := secretUnseal(ctx, repoDir); err != nil {
-			return nil, err
-		}
-	}
-
 	return &Checkout{
 		Export:       &Export{dir: repoDir},
 		upstream:     upstream,
@@ -195,7 +189,7 @@ func (c *Checkout) MoveTagAndPush(ctx context.Context, tagAction TagAction) erro
 }
 
 func (c *Checkout) Checkout(ctx context.Context, rev string) error {
-	return checkout(ctx, c.Dir(), rev)
+	return checkout(ctx, c.Dir(), rev, false)
 }
 
 func (c *Checkout) Add(ctx context.Context, path string) error {


### PR DESCRIPTION
Since the following commit, we do not call the Clone function anymore. As a result, the git-secret feature do not work anymore, the apply is done before doing the reveal of the secrets.

https://github.com/fluxcd/flux/commit/6eabb29d2501e1b8f3c6e4c18453cced20cdfdca#diff-ba9f11ecc3497d9993b933fdc2bd61e5, 

I am giving the gitSecret option value to the daemon object.. I did not find a better way to do it :(.