### PR TITLE
[Bugfix] Mount AKS service principal through secret instead of hostPath for ACR support

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -245,6 +245,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `registry.ecr.require`                            | `false`                                              | Refuse to start if the AWS API is not available
 | `registry.acr.enabled`                            | `false`                                              | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication
 | `registry.acr.hostPath`                           | `/etc/kubernetes/azure.json`                         | Alternative location of `azure.json` on the host
+| `registry.acr.secretName`                         | `None`                                               | Secret to mount instead of a hostPath
 | `registry.dockercfg.enabled`                      | `false`                                              | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file
 | `registry.dockercfg.secretName`                   | `None`                                               | Kubernetes secret with the docker config.json
 | `registry.dockercfg.configFileName`               | `/dockercfg/config.json`                             | Alternative path/name of the docker config.json

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -60,9 +60,14 @@ spec:
           medium: Memory
       {{- if .Values.registry.acr.enabled }}
       - name: acr-credentials
+        {{- if (not .Values.registry.acr.secretName) }}
         hostPath:
           path: "{{ .Values.registry.acr.hostPath }}"
           type: ""
+        {{- else }}
+        secret:
+          secretName: {{ .Values.registry.acr.secretName }}
+        {{- end }}
       {{- end }}
       {{- if .Values.registry.dockercfg.enabled }}
       - name: docker-credentials

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -218,6 +218,7 @@ registry:
   acr:
     enabled: false
     hostPath: /etc/kubernetes/azure.json
+    secretName: ""
   dockercfg:
     enabled: false
     secretName: ""

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,9 @@ reasons this can happen:
           path: /etc/kubernetes/azure.json
           type: ""
    ```
+   If you encounter [permission errors](https://github.com/Azure/AKS/issues/729), 
+   you can alternatively create a secret `acr-credentials` based on the
+   `azure.json` file and set `registry.acr.secretName=acr-credentials`.
  - Flux excludes images with no suitable manifest (linux amd64) in manifestlist
  - Flux doesn't yet understand image refs that use digests instead of
    tags; see


### PR DESCRIPTION
Add `registry.acr.secretName` chart parameter to work around permission errors on AKS when using ACR.

Fixes https://github.com/fluxcd/flux/issues/2431.

This [mimics the approach by external-dns](https://github.com/helm/charts/blob/5998aa6d6ac37813753285668a75287fcfc110ad/stable/external-dns/templates/deployment.yaml#L329-L337).