### PR TITLE
ACR secret mountPath fix

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -137,7 +137,11 @@ spec:
             mountPath: /var/fluxd/keygen
           {{- if .Values.registry.acr.enabled }}
           - name: acr-credentials
+            {{- if not .Values.registry.acr.secretName }}
             mountPath: /etc/kubernetes/azure.json
+            {{- else }}
+            mountPath: /etc/kubernetes/
+            {{- end }}
             readOnly: true
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}


### PR DESCRIPTION
Follow-up to PR #2434, I messed up, sorry about that. Verified this to work in my cluster this time.

The secret would be mounted into a _folder_ called `azure.json`, leading to problems. By instead mounting the secret into the folder `/etc/kubernetes/`, the file contained in the secret is mounted correctly as `/etc/kubernetes/azure.json`.

This still [mirrors the approach by external-dns](https://github.com/helm/charts/blob/5998aa6d6ac37813753285668a75287fcfc110ad/stable/external-dns/templates/deployment.yaml#L292-L300), I just missed a portion in the previous PR.