### PR TITLE
Using https protocol not require ssh config

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -542,7 +542,7 @@ func (d *Daemon) NotifyChange(ctx context.Context, change v9.Change) error {
 	switch change.Kind {
 	case v9.GitChange:
 		gitUpdate := change.Source.(v9.GitUpdate)
-		if gitUpdate.URL != d.Repo.Origin().URL && gitUpdate.Branch != d.GitConfig.Branch {
+		if gitUpdate.URL != d.Repo.Origin().SafeURL() && gitUpdate.Branch != d.GitConfig.Branch {
 			// It isn't strictly an _error_ to be notified about a repo/branch pair
 			// that isn't ours, but it's worth logging anyway for debugging.
 			d.Logger.Log("msg", "notified about unrelated change",

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -116,14 +116,13 @@ func (d *Daemon) Loop(stop chan struct{}, wg *sync.WaitGroup, logger log.Logger)
 			cancel()
 
 			if err != nil {
-				logger.Log("url", d.Repo.Origin().URL, "err", err)
+				logger.Log("url", d.Repo.Origin().SafeURL(), "err", err)
 				continue
 			}
 			if invalidCommit.Revision != "" {
 				logger.Log("err", "found invalid GPG signature for commit", "revision", invalidCommit.Revision, "key", invalidCommit.Signature.Key)
 			}
-
-			logger.Log("event", "refreshed", "url", d.Repo.Origin().URL, "branch", d.GitConfig.Branch, "HEAD", newSyncHead)
+			logger.Log("event", "refreshed", "url", d.Repo.Origin().SafeURL(), "branch", d.GitConfig.Branch, "HEAD", newSyncHead)
 			if newSyncHead != syncHead {
 				syncHead = newSyncHead
 				d.AskForSync()

--- a/git/working.go
+++ b/git/working.go
@@ -18,6 +18,7 @@ type Config struct {
 	Paths       []string // paths within the repo containing files we care about
 	NotesRef    string
 	UserName    string
+	APIKey      string
 	UserEmail   string
 	SigningKey  string
 	SetAuthor   bool

--- a/ssh/keyring.go
+++ b/ssh/keyring.go
@@ -11,7 +11,7 @@ type KeyRing interface {
 type sshKeyRing struct{}
 
 // NewNopSSHKeyRing returns a KeyRing that doesn't do anything.
-// It is meant for local development purposes when running fluxd outside a Kubernetes container.
+// It is meant for local development purposes when running fluxd outside a Kubernetes container or authentication to git done via HTTPS
 func NewNopSSHKeyRing() KeyRing {
 	return &sshKeyRing{}
 }


### PR DESCRIPTION
Following changes would allow:
- native support for git remote using HTTPS transport, using username and password for git clone, by using git-apikey and git-user arguments.
- usage of git-apikey and git-user arguments together with https transport, will skip ssh key pair creation
- will hide potential secrets in logs
- by using git-apikey argument and HTTPS transport, forces to remove username/password from git-url argument. That is done intentionally, as git-apikey should be treated not as config map, but as secret