### PR TITLE
Update namespace in clusterrolebinding for the example deployment yaml

### DIFF
--- a/deploy/flux-account.yaml
+++ b/deploy/flux-account.yaml
@@ -34,4 +34,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: flux
-    namespace: default
+    namespace: flux


### PR DESCRIPTION
The example deployment configs in `./deploy` has a small mismatch with the deployment configs applied through `fluxctl install`. 

- `flux` ClusterRoleBinding subject `flux` ServiceAccount specifies default namespace, through `fluxctl install` is `flux` namespace