### PR TITLE
Fix incorrent .flux.yaml example

### DIFF
--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -217,7 +217,7 @@ earlier.
 
 ```yaml
 version: 1
-commandUpdated:
+patchUpdated:
   generators:
     - command: helm template ../charts/mychart -f overrides.yaml
   patchFile: flux-patch.yaml


### PR DESCRIPTION
We were incorrectly using `commandUpdated` in a `patchUpdated` example.

