### PR TITLE
Tweak logged warning of unsupported resource kind

### DIFF
--- a/pkg/cluster/kubernetes/kubernetes.go
+++ b/pkg/cluster/kubernetes/kubernetes.go
@@ -144,7 +144,7 @@ func (c *Cluster) SomeWorkloads(ctx context.Context, ids []resource.ID) (res []c
 
 		resourceKind, ok := resourceKinds[kind]
 		if !ok {
-			c.logger.Log("warning", "unsupported kind", "resource", id)
+			c.logger.Log("warning", "automation of this resource kind is not supported", "resource", id)
 			continue
 		}
 


### PR DESCRIPTION
As the previous warning message did not provide enough context to the
user to be able to figure out why it was being marked as 'unsupported'.

Context: https://weave-community.slack.com/archives/C4U5ATZ9S/p1569340270209200