### PR TITLE
Use `flux` namespace in `deploy/` examples

### DIFF
--- a/deploy/flux-account.yaml
+++ b/deploy/flux-account.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     name: flux
   name: flux
+  namespace: flux
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -34,4 +35,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: flux
-    namespace: default
+    namespace: flux

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flux
+  namespace: flux
 spec:
   replicas: 1
   selector:

--- a/deploy/flux-ns.yaml
+++ b/deploy/flux-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux

--- a/deploy/flux-secret.yaml
+++ b/deploy/flux-secret.yaml
@@ -3,4 +3,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flux-git-deploy
+  namespace: flux
 type: Opaque

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - flux-ns.yaml
   - memcache-svc.yaml
   - memcache-dep.yaml
   - flux-account.yaml

--- a/deploy/memcache-dep.yaml
+++ b/deploy/memcache-dep.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: memcached
+  namespace: flux
 spec:
   replicas: 1
   selector:

--- a/deploy/memcache-svc.yaml
+++ b/deploy/memcache-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: memcached
+  namespace: flux
 spec:
   ports:
     - name: memcached

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -40,6 +40,7 @@ func main() {
 		params := install.TemplateParameters{
 			GitURL:    "git@github.com:fluxcd/flux-get-started",
 			GitBranch: "master",
+			Namespace: "flux",
 		}
 		manifests, err := install.FillInTemplates(params)
 		if err != nil {


### PR DESCRIPTION
This is so that the configuration is not effected by e.g. a namespace
context set in the `kubectl` config of the user, as this caused
problems during the creation of the `ClusterRoleBinding` which was set
to the `default` namespace, while the resources themselves would be
created in the user their configured namespace.

It also simplifies the 'Get started with Kustomize' guide, as a user
does no longer need to create the namespace as a prerequisite but is
still able to overwrite it by adding a `namespace: <targetNamespace>`
to their `kustomization.yaml`.

Supersedes #2454 