### PR TITLE
Fixed wrong chart repo for flux at documentation

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -169,7 +169,7 @@ called `flux-ssh-config` which in turn will be mounted into a volume named
      --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
      --set-string ssh.known_hosts="${KNOWN_HOSTS}" \
      --namespace flux \
-     chart/flux
+     fluxcd/flux
      ```
 
    - Using a file for setting `known_hosts`
@@ -185,7 +185,7 @@ called `flux-ssh-config` which in turn will be mounted into a volume named
      --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
      --set-file ssh.known_hosts=/tmp/flux_known_hosts \
      --namespace flux \
-     chart/flux
+     fluxcd/flux
      ```
      
 #### Connect Flux to a Weave Cloud instance


### PR DESCRIPTION
If you follow the guide, at the part Flux with a private git host, at point 1 the copy and paste code will fail because helm will search the chart at chart/flux instead of fluxcd/flux (where it is really).

