### PR TITLE
De-experimental-ise GC, namespace scoping, manifest generation

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -330,8 +330,8 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `helmOperator.affinity`                           | `{}`                                                 | Affinity properties for the helmOperator deployment
 | `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
-| `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (experimental, see [garbage collection](/docs/references/garbagecollection.md))
-| `syncGarbageCollection.dry`                       | `false`                                              | If enabled, fluxd won't delete any resources, but log the garbage collection output (experimental, see [garbage collection](/docs/references/garbagecollection.md))
+| `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](/docs/references/garbagecollection.md))
+| `syncGarbageCollection.dry`                       | `false`                                              | If enabled, fluxd won't delete any resources, but log the garbage collection output (see [garbage collection](/docs/references/garbagecollection.md))
 | `manifestGeneration`                              | `false`                                              | If enabled, fluxd will look for `.flux.yaml` and run Kustomize or other manifest generators
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -181,7 +181,7 @@ func main() {
 		sshKeygenDir = fs.String("ssh-keygen-dir", "", "directory, ideally on a tmpfs volume, in which to generate new SSH keys when necessary")
 
 		// manifest generation
-		manifestGeneration = fs.Bool("manifest-generation", false, "experimental; search for .flux.yaml files to generate manifests")
+		manifestGeneration = fs.Bool("manifest-generation", false, "search for .flux.yaml files to generate manifests")
 
 		// upstream connection settings
 		upstreamURL = fs.String("connect", "", "connect to an upstream service e.g., Weave Cloud, at this base address")

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -137,8 +137,8 @@ func main() {
 		// syncing
 		syncInterval = fs.Duration("sync-interval", 5*time.Minute, "apply config in git to cluster at least this often, even if there are no new commits")
 		syncTimeout  = fs.Duration("sync-timeout", 1*time.Minute, "duration after which sync operations time out")
-		syncGC       = fs.Bool("sync-garbage-collection", false, "experimental; delete resources that were created by fluxd, but are no longer in the git repo")
-		dryGC        = fs.Bool("sync-garbage-collection-dry", false, "experimental; only log what would be garbage collected, rather than deleting. Implies --sync-garbage-collection")
+		syncGC       = fs.Bool("sync-garbage-collection", false, "delete resources that were created by fluxd, but are no longer in the git repo")
+		dryGC        = fs.Bool("sync-garbage-collection-dry", false, "only log what would be garbage collected, rather than deleting. Implies --sync-garbage-collection")
 		syncState    = fs.String("sync-state", fluxsync.GitTagStateMode, fmt.Sprintf("method used by flux for storing state (one of {%s})", strings.Join([]string{fluxsync.GitTagStateMode, fluxsync.NativeStateMode}, ",")))
 
 		// registry

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -168,8 +168,11 @@ func main() {
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "name of the k8s secret used to store the private SSH key")
 		k8sSecretVolumeMountPath = fs.String("k8s-secret-volume-mount-path", "/etc/fluxd/ssh", "mount location of the k8s secret storing the private SSH key")
 		k8sSecretDataKey         = fs.String("k8s-secret-data-key", "identity", "data key holding the private SSH key within the k8s secret")
-		k8sNamespaceWhitelist    = fs.StringSlice("k8s-namespace-whitelist", []string{}, "experimental, optional: restrict the view of the cluster to the namespaces listed. All namespaces are included if this is not set")
-		k8sAllowNamespace        = fs.StringSlice("k8s-allow-namespace", []string{}, "experimental: restrict all operations to the provided namespaces")
+
+		// k8s-scope settings
+		k8sNamespaceWhitelist    = fs.StringSlice("k8s-namespace-whitelist", []string{}, "restrict the view of the cluster to the namespaces listed. All namespaces are included if this is not set")
+		k8sAllowNamespace        = fs.StringSlice("k8s-allow-namespace", []string{}, "restrict all operations to the provided namespaces")
+
 		k8sVerbosity             = fs.Int("k8s-verbosity", 0, "klog verbosity level")
 
 		// SSH key generation

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -122,15 +122,13 @@ No. It applies changes to git only when a Flux command or API call makes them.
 
 ### Will Flux delete resources when I remove them from git?
 
-Flux has an experimental (for now) garbage collection feature,
-enabled by passing the command-line flag `--sync-garbage-collection`
-to `fluxd`.
+Flux has an garbage collection feature, enabled by passing the command-line
+flag `--sync-garbage-collection` to `fluxd`.
 
 The garbage collection is conservative: it is designed to not delete
 resources that were not created by `fluxd`. This means it will sometimes
-_not_ delete resources that _were_ created by `fluxd`, when
-reconfigured. Read more about garbage collection
-[here](references/garbagecollection.md).
+_not_ delete resources that _were_ created by `fluxd`, when reconfigured.
+Read more about garbage collection [here](references/garbagecollection.md).
 
 ### How do I give Flux access to an image registry?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -384,9 +384,9 @@ Disable image scanning for all images:
 
 Yes!
 
-Flux experimentally supports technology-agnostic manifest factorization through
-`.flux.yaml` configuration files placed in the Git repository. To enable this
-feature please supply `fluxd` with flag `--manifest-generation=true`.
+Flux supports technology-agnostic manifest factorization through `.flux.yaml` configuration
+files placed in the Git repository. To enable it supply the command-line flag
+`--manifest-generation=true` to `fluxd`.
 
 See [`.flux.yaml` configuration files documentation](references/fluxyaml-config-files.md) for
 further details.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -269,8 +269,6 @@ Here's the relevant docs for some common CI systems:
 
 ### Can I restrict the namespaces that Flux can see or operate on?
 
-Yes, though support for this is experimental at the minute.
-
 Flux will only operate on the namespaces that its service account has
 access to; so the most effective way to restrict it to certain
 namespaces is to use Kubernetes' role-based access control (RBAC) to
@@ -278,9 +276,8 @@ make a service account that has restricted access itself. You may need
 to experiment to find the most restrictive permissions that work for
 your case.
 
-You will need to use the (experimental) command-line flag
-`--k8s-allow-namespace` to enumerate the namespaces that Flux
-attempts to scan for workloads.
+You will need to use the command-line flag `--k8s-allow-namespace`
+to enumerate the namespaces that Flux attempts to scan for workloads.
 
 ### Can I change the namespace Flux puts things in by default?
 

--- a/docs/references/daemon.md
+++ b/docs/references/daemon.md
@@ -59,8 +59,9 @@ Version controlling of cluster manifests provides reproducibility and a historic
 | --git-timeout                                    | `20s`                    | duration after which git operations time out
 | **syncing:** control over how config is applied to the cluster
 | --sync-interval                                  | `5m`                     | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs
-| --sync-timeout                                   | `1m`                     |  duration after which sync operations time out
-| --sync-garbage-collection                        | `false`                  | experimental: when set, fluxd will delete resources that it created, but are no longer present in git
+| --sync-timeout                                   | `1m`                     | duration after which sync operations time out
+| --sync-garbage-collection                        | `false`                  | when set, fluxd will delete resources that it created, but are no longer present in git
+| --sync-garbage-collection-dry                    | `false`                  | only log what would be garbage collected, rather than deleting. Implies --sync-garbage-collection
 | **registry cache:** (none of these need overriding, usually)
 | --memcached-hostname                             | `memcached`                        | hostname for memcached service to use for caching image metadata
 | --memcached-timeout                              | `1s`                               | maximum time to wait before giving up on memcached requests

--- a/docs/references/daemon.md
+++ b/docs/references/daemon.md
@@ -90,7 +90,7 @@ Version controlling of cluster manifests provides reproducibility and a historic
 | --ssh-keygen-bits                                |                                    | -b argument to ssh-keygen (default unspecified)
 | --ssh-keygen-type                                |                                    | -t argument to ssh-keygen (default unspecified)
 | **manifest generation**
-| --manifest-generation                            | false                              | experimental; search for .flux.yaml files to generate manifests
+| --manifest-generation                            | false                              | search for .flux.yaml files to generate manifests
 
 ## More information
 

--- a/docs/references/daemon.md
+++ b/docs/references/daemon.md
@@ -82,7 +82,7 @@ Version controlling of cluster manifests provides reproducibility and a historic
 | --k8s-secret-volume-mount-path                   | `/etc/fluxd/ssh`                   | mount location of the k8s secret storing the private SSH key
 | --k8s-secret-data-key                            | `identity`                         | data key holding the private SSH key within the k8s secret
 | **k8s configuration**
-| --k8s-allow-namespace                            |                                    | experimental: restrict all operations to the provided namespaces
+| --k8s-allow-namespace                            |                                    | restrict all operations to the provided namespaces
 | **upstream service**
 | --connect                                        |                                    | connect to an upstream service e.g., Weave Cloud, at this base address
 | --token                                          |                                    | authentication token for upstream service

--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -2,7 +2,7 @@
 
 ## Enabling search of `.flux.yaml` files
 
-This feature is still experimental. To enable it please supply `fluxd` with flag `--manifest-generation=true`.
+To enable it supply the command-line flag `--manifest-generation=true` to `fluxd`.
 
 ## Goal
 


### PR DESCRIPTION
This PR de-experimental-ises the following features, as they have had a fair incubation period without running into major issues:

- garbage collection
- namespace scoping
- manifest generation