### PR TITLE
Update FAQ advice on using ignore annotation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -307,45 +307,27 @@ and mounting from a configmap will make it read-only and thus
 effectively disable the caching. For that reason, take care to mount
 your configmap elsewhere in the filesystem, as the example shows.
 
-### Can I temporarily make Flux ignore a deployment?
+### Can I temporarily make Flux ignore a manifest?
 
-Yes. The easiest way to do that is to use the following annotation
-*in the manifest files*:
+Yes. The easiest way to do that is to use the following annotation in the manifest, and commit
+the change to git:
 
 ```yaml
     fluxcd.io/ignore: true
 ```
 
-To stop ignoring these annotated resources, you simply remove the
-annotation from the manifests in git. A live example can be seen
+To stop ignoring these annotated resources, you simply remove the annotation from the manifests in git.
+A live example can be seen
 [here](https://github.com/stefanprodan/openfaas-flux/blob/master/secrets/openfaas-token.yaml).
-This will work for any type of resource.
 
-Sometimes it might be easier to annotate a *running resource in
-the cluster* as opposed to committing a change to git. Please note
-that this will only work with resources of the type `namespace`
-and the set of controllers in
-[resourcekinds.go](https://github.com/fluxcd/flux/blob/master/cluster/kubernetes/resourcekinds.go),
-namely `deployment`, `daemonset`, `cronjob`, `statefulset` and
-`fluxhelmrelease`).
+Flux will ignore any resource that has the annotation _either_ in git, or in the cluster itself;
+sometimes it may be easier to annotate a *running resource in the cluster* as opposed to committing
+a change to git.
 
-If the annotation is just carried in the cluster, the easiest way
-to remove it is to run:
-
-```sh
-kubectl annotate <resource> "fluxcd.io/ignore"-
-```
-
-Mixing both kinds of annotations (in-git and in-cluster), can make
-it a bit hard to figure out how/where to undo the change (cf
-[flux#1211](https://github.com/fluxcd/flux/issues/1211)).
-
-The full story is this: Flux looks at the files and the running
-resources when deciding whether what to apply. But it gets the
-running resources by exporting them from the cluster, and that
-only returns the kinds of resource mentioned above. So,
-annotating a running resource only works if it's one of those
-kinds; putting the annotation in the file always works.
+Mixing both kinds of annotations (in git, and in the cluster), can make it a bit hard to figure out
+how/where to undo the change (cf [flux#1211](https://github.com/fluxcd/flux/issues/1211)). If the
+annotation exists in either the cluster or in git, it will be respected, so you may need to remove
+it from both places.
 
 ### How can I prevent Flux overriding the replicas when using HPA?
 


### PR DESCRIPTION
It's no longer the case that ignore works via Export (and therefore, only sees annotations on workloads and namespaces). Fixes #2501.
