### PR TITLE
Fix typo in guide index docs

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -8,6 +8,6 @@ Guides
    :maxdepth: 1
 
    provide-own-ssh-key
-   use-git-over-https
+   use-git-https
    use-private-git-host
    upgrading-to-1.0


### PR DESCRIPTION
Using a non-existent filename causes it to not be listed in the sidebar, this PR fixes this.