### PR TITLE
Add an API to trigger a Git sync

### DIFF
--- a/pkg/api/v11/api.go
+++ b/pkg/api/v11/api.go
@@ -17,6 +17,8 @@ type ListServicesOptions struct {
 type Server interface {
 	v10.Server
 
+	SyncGit(context.Context) error
+
 	ListServicesWithOptions(ctx context.Context, opts ListServicesOptions) ([]v6.ControllerStatus, error)
 
 	// NB Upstream methods move into the public API, since

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -550,6 +550,11 @@ func (d *Daemon) NotifyChange(ctx context.Context, change v9.Change) error {
 	return nil
 }
 
+func (d *Daemon) SyncGit(ctx context.Context) error {
+	d.Repo.Notify()
+	return nil
+}
+
 // JobStatus - Ask the daemon how far it's got committing things; in particular, is the job
 // queued? running? committed? If it is done, the commit ref is returned.
 func (d *Daemon) JobStatus(ctx context.Context, jobID job.ID) (job.Status, error) {

--- a/pkg/http/client/client.go
+++ b/pkg/http/client/client.go
@@ -68,6 +68,10 @@ func (c *Client) NotifyChange(ctx context.Context, change v9.Change) error {
 	return c.PostWithBody(ctx, transport.Notify, change)
 }
 
+func (c *Client) SyncGit(ctx context.Context) error {
+	return c.Post(ctx, transport.SyncGit)
+}
+
 func (c *Client) ListServices(ctx context.Context, namespace string) ([]v6.ControllerStatus, error) {
 	var res []v6.ControllerStatus
 	err := c.Get(ctx, &res, transport.ListServices, "namespace", namespace)

--- a/pkg/http/daemon/server.go
+++ b/pkg/http/daemon/server.go
@@ -53,6 +53,7 @@ func NewHandler(s api.Server, r *mux.Router) http.Handler {
 	r.Get(transport.Ping).HandlerFunc(handle.Ping)
 	r.Get(transport.Version).HandlerFunc(handle.Version)
 	r.Get(transport.Notify).HandlerFunc(handle.Notify)
+	r.Get(transport.SyncGit).HandlerFunc(handle.SyncGit)
 
 	// v6-v11 handlers
 	r.Get(transport.ListServices).HandlerFunc(handle.ListServicesWithOptions)
@@ -109,6 +110,15 @@ func (s HTTPServer) Notify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.server.NotifyChange(r.Context(), change); err != nil {
+		transport.ErrorResponse(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s HTTPServer) SyncGit(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	if err := s.server.SyncGit(r.Context()); err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
 	}

--- a/pkg/http/routes.go
+++ b/pkg/http/routes.go
@@ -5,6 +5,7 @@ const (
 	Ping    = "Ping"
 	Version = "Version"
 	Notify  = "Notify"
+	SyncGit = "SyncGit"
 
 	ListServices            = "ListServices"
 	ListServicesWithOptions = "ListServicesWithOptions"

--- a/pkg/http/transport.go
+++ b/pkg/http/transport.go
@@ -32,6 +32,7 @@ func NewAPIRouter() *mux.Router {
 	r.NewRoute().Name(Ping).Methods("GET").Path("/v11/ping")
 	r.NewRoute().Name(Version).Methods("GET").Path("/v11/version")
 	r.NewRoute().Name(Notify).Methods("POST").Path("/v11/notify")
+	r.NewRoute().Name(SyncGit).Methods("POST").Path("/v11/sync-git")
 
 	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services")
 	r.NewRoute().Name(ListServicesWithOptions).Methods("GET").Path("/v11/services")

--- a/pkg/remote/logging.go
+++ b/pkg/remote/logging.go
@@ -133,3 +133,12 @@ func (p *ErrorLoggingServer) NotifyChange(ctx context.Context, change v9.Change)
 	}()
 	return p.server.NotifyChange(ctx, change)
 }
+
+func (p *ErrorLoggingServer) SyncGit(ctx context.Context) (err error) {
+	defer func() {
+		if err != nil {
+			p.logger.Log("method", "SyncGit", "error", err)
+		}
+	}()
+	return p.server.SyncGit(ctx)
+}

--- a/pkg/remote/metrics.go
+++ b/pkg/remote/metrics.go
@@ -157,3 +157,13 @@ func (i *instrumentedServer) NotifyChange(ctx context.Context, change v9.Change)
 	}(time.Now())
 	return i.s.NotifyChange(ctx, change)
 }
+
+func (i *instrumentedServer) SyncGit(ctx context.Context) (err error) {
+	defer func(begin time.Time) {
+		requestDuration.With(
+			fluxmetrics.LabelMethod, "SyncGit",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
+		).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return i.s.SyncGit(ctx)
+} 

--- a/pkg/remote/mock.go
+++ b/pkg/remote/mock.go
@@ -40,6 +40,7 @@ type MockServer struct {
 	UpdateManifestsError   error
 
 	NotifyChangeError error
+	SyncGitError error
 
 	SyncStatusAnswer []string
 	SyncStatusError  error
@@ -90,6 +91,10 @@ func (p *MockServer) UpdateManifests(ctx context.Context, s update.Spec) (job.ID
 
 func (p *MockServer) NotifyChange(ctx context.Context, change v9.Change) error {
 	return p.NotifyChangeError
+}
+
+func (p *MockServer) SyncGit(ctx context.Context) error {
+	return p.SyncGitError
 }
 
 func (p *MockServer) SyncStatus(context.Context, string) ([]string, error) {
@@ -234,6 +239,10 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.Server) api.Server) {
 
 	change := v9.Change{Kind: v9.GitChange, Source: v9.GitUpdate{URL: "git@example.com:foo/bar"}}
 	if err := client.NotifyChange(ctx, change); err != nil {
+		t.Error(err)
+	}
+
+	if err := client.SyncGit(ctx); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/remote/rpc/baseclient.go
+++ b/pkg/remote/rpc/baseclient.go
@@ -56,6 +56,10 @@ func (bc baseClient) NotifyChange(context.Context, v9.Change) error {
 	return remote.UpgradeNeededError(errors.New("NotifyChange method not implemented"))
 }
 
+func (bc baseClient) SyncGit(context.Context) error {
+	return remote.UpgradeNeededError(errors.New("SyncGit method not implemented"))
+}
+
 func (bc baseClient) JobStatus(context.Context, job.ID) (job.Status, error) {
 	return job.Status{}, remote.UpgradeNeededError(errors.New("JobStatus method not implemented"))
 }

--- a/pkg/remote/rpc/clientV11.go
+++ b/pkg/remote/rpc/clientV11.go
@@ -50,7 +50,7 @@ func (p *RPCClientV11) ListServicesWithOptions(ctx context.Context, opts v11.Lis
 
 func (p *RPCClientV11) SyncGit(ctx context.Context) error {
 	var resp SyncGitResponse
-	err := p.client.Call("RPCServer.SyncGit", "", &resp)
+	err := p.client.Call("RPCServer.SyncGit", struct{}{}, &resp)
 	if err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			err = remote.FatalError{err}

--- a/pkg/remote/rpc/clientV11.go
+++ b/pkg/remote/rpc/clientV11.go
@@ -47,3 +47,16 @@ func (p *RPCClientV11) ListServicesWithOptions(ctx context.Context, opts v11.Lis
 	}
 	return resp.Result, err
 }
+
+func (p *RPCClientV11) SyncGit(ctx context.Context) error {
+	var resp SyncGitResponse
+	err := p.client.Call("RPCServer.SyncGit", "", &resp)
+	if err != nil {
+		if _, ok := err.(rpc.ServerError); !ok && err != nil {
+			err = remote.FatalError{err}
+		}
+	} else if resp.ApplicationError != nil {
+		err = resp.ApplicationError
+	}
+	return err
+}

--- a/pkg/remote/rpc/server.go
+++ b/pkg/remote/rpc/server.go
@@ -164,6 +164,23 @@ func (p *RPCServer) NotifyChange(c v9.Change, resp *NotifyChangeResponse) error 
 	return err
 }
 
+type SyncGitResponse struct {
+	ApplicationError *fluxerr.Error
+}
+
+func (p *RPCServer) SyncGit(_, resp *SyncGitResponse) error {
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+	err := p.s.SyncGit(ctx)
+	if err != nil {
+		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
+			resp.ApplicationError = err
+			return nil
+		}
+	}
+	return err
+}
+
 type JobStatusResponse struct {
 	Result           job.Status
 	ApplicationError *fluxerr.Error


### PR DESCRIPTION
As per the discussion in #1128, there are currently no convenient API methods that could be used as a webhook interface for Git. For the simple need of letting Flux know that there are changes to be synced, `/api/flux/v11/sync-git` can be used. 
It requires no arguments, only triggers a `Repo.Notify()` call, same as `/api/flux/v11/notify` does if the supplied payload checks out.