### PR TITLE
Break generational cycle

### DIFF
--- a/cmd/fluxctl/install_cmd.go
+++ b/cmd/fluxctl/install_cmd.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/fluxcd/flux/pkg/install"
 )
 
-type installOpts install.TemplateParameters
+type installOpts struct {
+	install.TemplateParameters
+	outputDir string
+}
 
 func newInstall() *installOpts {
 	return &installOpts{}
@@ -23,22 +28,23 @@ func (opts *installOpts) Command() *cobra.Command {
 fluxctl install --git-url 'git@github.com:<your username>/flux-get-started' | kubectl -f -`,
 		RunE: opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.GitURL, "git-url", "", "",
+	cmd.Flags().StringVar(&opts.GitURL, "git-url", "",
 		"URL of the Git repository to be used by Flux, e.g. git@github.com:<your username>/flux-get-started")
-	cmd.Flags().StringVarP(&opts.GitBranch, "git-branch", "", "master",
+	cmd.Flags().StringVar(&opts.GitBranch, "git-branch", "master",
 		"Git branch to be used by Flux")
-	cmd.Flags().StringSliceVarP(&opts.GitPaths, "git-paths", "", []string{},
+	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-paths", []string{},
 		"Relative paths within the Git repo for Flux to locate Kubernetes manifests")
-	cmd.Flags().StringSliceVarP(&opts.GitPaths, "git-path", "", []string{},
+	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-path", []string{},
 		"Relative paths within the Git repo for Flux to locate Kubernetes manifests")
-	cmd.Flags().StringVarP(&opts.GitLabel, "git-label", "", "flux",
+	cmd.Flags().StringVar(&opts.GitLabel, "git-label", "flux",
 		"Git label to keep track of Flux's sync progress; overrides both --git-sync-tag and --git-notes-ref")
-	cmd.Flags().StringVarP(&opts.GitUser, "git-user", "", "Flux",
+	cmd.Flags().StringVar(&opts.GitUser, "git-user", "Flux",
 		"Username to use as git committer")
-	cmd.Flags().StringVarP(&opts.GitEmail, "git-email", "", "",
+	cmd.Flags().StringVar(&opts.GitEmail, "git-email", "",
 		"Email to use as git committer")
-	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "", getKubeConfigContextNamespace("default"),
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", getKubeConfigContextNamespace("default"),
 		"Cluster namespace where to install flux")
+	cmd.Flags().StringVarP(&opts.outputDir, "output-dir", "o", "", "a directory in which to write individual manifests, rather than printing to stdout")
 
 	// Hide and deprecate "git-paths", which was wrongly introduced since its inconsistent with fluxd's git-path flag
 	cmd.Flags().MarkHidden("git-paths")
@@ -54,15 +60,35 @@ func (opts *installOpts) RunE(cmd *cobra.Command, args []string) error {
 	if opts.GitEmail == "" {
 		return fmt.Errorf("please supply a valid --git-email argument")
 	}
-	manifests, err := install.FillInTemplates(install.TemplateParameters(*opts))
+	manifests, err := install.FillInTemplates(opts.TemplateParameters)
 	if err != nil {
 		return err
 	}
+
+	writeManifest := func(fileName string, content []byte) error {
+		_, err := os.Stdout.Write(content)
+		return err
+	}
+
+	if opts.outputDir != "" {
+		info, err := os.Stat(opts.outputDir)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s is not a directory", opts.outputDir)
+		}
+		writeManifest = func(fileName string, content []byte) error {
+			path := filepath.Join(opts.outputDir, fileName)
+			fmt.Fprintf(os.Stderr, "writing %s\n", path)
+			return ioutil.WriteFile(path, content, os.FileMode(0666))
+		}
+	}
+
 	for fileName, content := range manifests {
-		if _, err := os.Stdout.Write(content); err != nil {
+		if err := writeManifest(fileName, content); err != nil {
 			return fmt.Errorf("cannot output manifest file %s: %s", fileName, err)
 		}
-
 	}
 
 	return nil

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -145,6 +145,9 @@ spec:
         # Include this if you want to restrict the manifests considered by flux
         # to those under the following relative paths in the git repository
         # - --git-path=subdir1,subdir2
+        - --git-label=flux-sync
+        - --git-user=Flux automation
+        - --git-email=flux@example.com
 
         # Include these two to enable git commit signing
         # - --git-gpg-key-import=/root/gpg-import

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -4,58 +4,33 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/shurcooL/vfsgen"
-
-	"github.com/fluxcd/flux/pkg/install"
 )
 
 func main() {
 	usage := func() {
-		fmt.Fprintf(os.Stderr, "usage: %s {embedded-templates,deploy}\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "usage: %s\n", os.Args[0])
 		os.Exit(1)
 	}
-	if len(os.Args) != 2 {
+	if len(os.Args) != 1 {
 		usage()
 	}
-	switch os.Args[1] {
-	case "embedded-templates":
-		var fs http.FileSystem = modTimeFS{
-			fs: http.Dir("templates/"),
-		}
-		err := vfsgen.Generate(fs, vfsgen.Options{
-			Filename:     "generated_templates.gogen.go",
-			PackageName:  "install",
-			VariableName: "templates",
-		})
-		if err != nil {
-			log.Fatalln(err)
-		}
-	case "deploy":
-		params := install.TemplateParameters{
-			GitURL:    "git@github.com:fluxcd/flux-get-started",
-			GitBranch: "master",
-			Namespace: "flux",
-		}
-		manifests, err := install.FillInTemplates(params)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: failed to fill in templates: %s\n", err)
-			os.Exit(1)
-		}
-		for fileName, contents := range manifests {
-			if err := ioutil.WriteFile(fileName, contents, 0600); err != nil {
-				fmt.Fprintf(os.Stderr, "error: failed to write deploy file %s: %s\n", fileName, err)
-				os.Exit(1)
-			}
-		}
 
-	default:
-		usage()
+	var fs http.FileSystem = modTimeFS{
+		fs: http.Dir("templates/"),
+	}
+	err := vfsgen.Generate(fs, vfsgen.Options{
+		Filename:     "generated_templates.gogen.go",
+		PackageName:  "install",
+		VariableName: "templates",
+	})
+	if err != nil {
+		log.Fatalln(err)
 	}
 }
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -12,6 +12,8 @@ import (
 	"github.com/shurcooL/httpfs/vfsutil"
 )
 
+//go:generate go run generate.go
+
 type TemplateParameters struct {
 	GitURL             string
 	GitBranch          string


### PR DESCRIPTION
Adapted from commit msg:

For `fluxctl install`, we embed a set of templates in the fluxctl binary by generating a fake filesystem as Go code (pkg/install/generated_templates.gogen.go). But the code that generates the fake filesystem also _depends_ on the fake filesystem, since it does double duty as a program for generating example manifests from those templates.

This leads to a problem: if anything has upset the generation process, it's not possible to regenerate the files, since the generation tool won't build.

A related problem, worked around elsewhere (#2473), is that it's easy to introduce spurious differences in the generated code -- which, since it's checked in -- means painful merges.

In general we don't care about the generated Go code, only about what it produces. This PR removes it from git and from the uncommitted change detection (`make check-generated`); and uses a new capability of `fluxctl install` to write to individual files to generate the example files under deploy/, removing the need for the code generating program to depend on the code it's generating.