### PR TITLE
fix string trim func in findErrorMessage func

### DIFF
--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -469,7 +469,7 @@ func findErrorMessage(output io.Reader) string {
 		case strings.HasPrefix(sc.Text(), "ERROR fatal: "): // Saw this error on ubuntu systems
 			return sc.Text()
 		case strings.HasPrefix(sc.Text(), "error:"):
-			return strings.Trim(sc.Text(), "error: ")
+			return strings.TrimPrefix(sc.Text(), "error: ")
 		}
 	}
 	return ""


### PR DESCRIPTION
`Trim` is a char based func, it is dangerous used in here, I think `TrimPrefix` is what we may want here, see here: https://play.golang.org/p/OTBFKMzklMZ

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
