### PR TITLE
Fix command in fluxyaml config example

### DIFF
--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -224,6 +224,6 @@ earlier.
 version: 1
 patchUpdated:
   generators:
-    - command: helm template ../charts/mychart -f overrides.yaml
+    - command: kustomize build .
   patchFile: flux-patch.yaml
 ```


### PR DESCRIPTION
The last example in the `.flux.yaml` manifest doc refers to the earlier Kustomize example but mistakenly includes the helm command.