### PR TITLE
Fix some steps in README.md to install flux by helm

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -81,19 +81,19 @@ to securely provide the HTTPS credentials which then can be used in the
    - [GitHub](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
    - [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token)
    - [BitBucket](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
-   
+
 1. Create a secret with your `GIT_AUTHUSER` (the username the token belongs
    to) and the `GIT_AUTHKEY` you created in the first step:
 
    ```sh
-   kubectl create secret generic flux-git-auth --from-literal=GIT_AUTHUSER=<username> --from-literal=GIT_AUTHKEY=<token>
+   kubectl create secret generic flux-git-auth --namespace flux --from-literal=GIT_AUTHUSER=<username> --from-literal=GIT_AUTHKEY=<token>
    ```
 
 1. Install Flux:
 
    ```sh
    helm install --name flux \
-   --set git.url='https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com:fluxcd/flux-get-started.git' \
+   --set git.url='https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/fluxcd/flux-get-started.git' \
    --set env.secretName=flux-git-auth \
    --namespace flux \
    fluxcd/flux
@@ -153,7 +153,7 @@ called `flux-ssh-config` which in turn will be mounted into a volume named
      --namespace flux \
      fluxcd/flux
      ```
-     
+
 #### Connect Flux to a Weave Cloud instance
 
 ```sh


### PR DESCRIPTION
# Summary 
Update next steps in README.md for instruction to install flux by helm.
1. Update github URL format for https
1. Add namespace to create k8s secret

# Error details
1. If we see the logs on k8s pods, next logs can be seen (USERNAME, TOKEN, and REPOSITORY are not the real values and they should be real values).
    ```
    ts=2019-10-14T05:47:42.358161033Z caller=loop.go:101 component=sync-loop err="git repo not ready: git clone --mirror: fatal: unable to access 'https://USERNAME:TOKEN@github.com:at-ishikawa/REPOSITORY.git/': URL using bad/illegal format or missing URL, full output:\n Cloning into bare repository '/tmp/flux-gitclone859872933'...\nfatal: unable to access 'https://USERNAME:TOKEN@github.com:at-ishikawa/REPOSITORY.git/': URL using bad/illegal format or missing URL\n"
    ```

1. If we do not add namespace in flux secret, we can get following events on the result of `kubectl describe pods`.
    ```
    # kubectl -n flux describe pods -l app=flux
    ## A lot of details
    Events:
      Type     Reason     Age               From                                                       Message
      ----     ------     ----              ----                                                       -------
    ## A lot of events
      Warning  Failed     1s (x9 over 94s)  kubelet, gke-cluster-preemptible-node-pool-9d547b9e-8lj1  Error: secrets "flux-git-auth" not found
    ```