### PR TITLE
🚧 Provide basic observability over synchronisation errors.

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -18,6 +18,33 @@ var (
 		Buckets:   []float64{0.5, 5, 10, 20, 30, 40, 50, 60, 75, 90, 120, 240},
 	}, []string{fluxmetrics.LabelSuccess})
 
+	// syncErrorCount provides a way for observing git-to-cluster
+	// synchronisation errors without needing to inspect the pod's logs.
+	syncErrorCount = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "sync_error_count",
+		Help:      "Count of git-to-cluster synchronisation errors.",
+	}, []string{})
+
+	// lastSyncTimestamp will contain the timestamp at which the git-to-cluster
+	// synchronisation was last attempted.
+	lastSyncTimestamp = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "last_sync_timestamp",
+		Help:      "The timestamp at which git-to-cluster synchronisation was last attempted.",
+	}, []string{})
+
+	// lastSuccessfulSyncTimestamp will contain the timestamp at which the
+	// git-to-cluster synchronisation was last attempted successfully.
+	lastSuccessfulSyncTimestamp = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "last_successful_sync_timestamp",
+		Help:      "The timestamp at which git-to-cluster synchronisation was last successfully attempted.",
+	}, []string{})
+
 	// For most jobs, the majority of the time will be spent pushing
 	// changes (git objects and refs) upstream.
 	jobDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{


### PR DESCRIPTION
This PR implements basic observability over git-to-cluster synchronisation errors, as requested in #1340. The implementation introductes a new metric:

* `sync_error_count`, as suggested in the original issue, which provides a counter of synchronisation errors.

While I believe `sync_error_count` has its own merit and use-cases, I am also introducting two additional metrics:

* `last_sync_timestamp`, which provides the timestamp at which synchronisation was last attempted; and
* `last_successful_sync_timestamp`, which provides the timestamp at which synchronisation was last attempted _successfully_.

It follows that whenever these two metrics differ, the git-to-cluster synchronisation is _currently_ failing. As an example, this is what metrics look like after a successful synchronisation:

```
(...)
# HELP flux_daemon_last_successful_sync_timestamp The timestamp at which git-to-cluster synchronisation was last successfully attempted.
# TYPE flux_daemon_last_successful_sync_timestamp gauge
flux_daemon_last_successful_sync_timestamp 1.5716875893542927e+18
# HELP flux_daemon_last_sync_timestamp The timestamp at which git-to-cluster synchronisation was last attempted.
# TYPE flux_daemon_last_sync_timestamp gauge
flux_daemon_last_sync_timestamp 1.5716875893542927e+18
(...())
# HELP flux_daemon_sync_error_count Count of git-to-cluster synchronisation errors.
# TYPE flux_daemon_sync_error_count counter
flux_daemon_sync_error_count 0
(...)
```

And this is what happens after a failed synchronisation attempt (in this case, I had pushed a malformed YAML file to the repository being synced):

```
# HELP flux_daemon_last_successful_sync_timestamp The timestamp at which git-to-cluster synchronisation was last successfully attempted.
# TYPE flux_daemon_last_successful_sync_timestamp gauge
flux_daemon_last_successful_sync_timestamp 1.5716877452956073e+18
# HELP flux_daemon_last_sync_timestamp The timestamp at which git-to-cluster synchronisation was last attempted.
# TYPE flux_daemon_last_sync_timestamp gauge
flux_daemon_last_sync_timestamp 1.5716877717151754e+18
(...)
# HELP flux_daemon_sync_error_count Count of git-to-cluster synchronisation errors.
# TYPE flux_daemon_sync_error_count counter
flux_daemon_sync_error_count 1
```

I'd very much like to hear everyone's thoughts on this. 🙂 If everyone's happy with this in its current form, I'll work on adding the proper documentation.

Closes #1340.