### PR TITLE
Restore missing namespaces to workload IDs

### DIFF
--- a/pkg/cluster/kubernetes/images.go
+++ b/pkg/cluster/kubernetes/images.go
@@ -145,7 +145,7 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 
 			imageCreds := make(registry.ImageCreds)
 			for _, workload := range workloads {
-				logger := log.With(c.logger, "resource", resource.MakeID(ns, kind, workload.GetName()))
+				logger := log.With(c.logger, "resource", resource.MakeID(workload.GetNamespace(), kind, workload.GetName()))
 				mergeCredentials(logger.Log, c.includeImage, c.client, ns, workload.podTemplate, imageCreds, seenCreds)
 			}
 


### PR DESCRIPTION
The commit 852a02c5a194efb68182b9b3fcf85b13 changed handling of the
"all namespace" case in kubernetes.go, such that instead of
enumerating all namespaces then asking for the resources in each, a
special value is used (`meta_v1.NamespaceAll`) that signifies to the
API to look in all namespaces.

Before the change, the namespace-valued loop var was used as the
namespace in each resource's ID as it was added to the
result. However, since this code now deals with the "all namespaces"
case too, it can take the value of the special signifier -- which
results in invalid resource IDs.

To correct this, the namespace reported by the fetched resource itself
is used.

Similarly, we can no longer compare the loop var to the requested
namespace -- if all namespaces are allowed, it will never be
equal. Instead of doing that, just make the namespaces looped over the
_intersection_ of the allowed namespaces and the requested namespace.
