### PR TITLE
Chart: Fix memcached PSP

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.memcached.pullSecret }}
       {{- end }}
+      {{- if .Values.rbac.pspEnabled }}
+      serviceAccountName: {{ template "flux.serviceAccountName" . }}
+      {{- end }}
       containers:
       - name: memcached
         image: {{ .Values.memcached.repository }}:{{ .Values.memcached.tag }}


### PR DESCRIPTION
Set service account name to memcached deployment when PSP is enabled

Fix: #2540
