### PR TITLE
Add `SafeURL` helper method to `GitRemoteConfig`

### DIFF
--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -46,10 +46,10 @@ func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
 	case git.RepoReady:
 		break
 	default:
-		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.URL, string(gitConfig.Status))
+		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.SafeURL(), string(gitConfig.Status))
 	}
 
-	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.URL)
+	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.SafeURL())
 
 	updateSpec := update.Spec{
 		Type: update.Sync,

--- a/pkg/api/v6/api.go
+++ b/pkg/api/v6/api.go
@@ -49,7 +49,7 @@ type ControllerStatus struct {
 // --- config types
 
 type GitRemoteConfig struct {
-	URL    string `json:"url"`
+	git.Remote
 	Branch string `json:"branch"`
 	Path   string `json:"path"`
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -629,7 +629,7 @@ func (d *Daemon) GitRepoConfig(ctx context.Context, regenerate bool) (v6.GitConf
 	}
 	return v6.GitConfig{
 		Remote: v6.GitRemoteConfig{
-			URL:    origin.URL,
+			Remote: origin,
 			Branch: d.GitConfig.Branch,
 			Path:   path,
 		},

--- a/pkg/git/url.go
+++ b/pkg/git/url.go
@@ -10,7 +10,8 @@ import (
 
 // Remote points at a git repo somewhere.
 type Remote struct {
-	URL string // clone from here
+	// URL is where we clone from
+	URL string `json:"url"`
 }
 
 func (r Remote) SafeURL() string {


### PR DESCRIPTION
During the development of the (secure) Git HTTPS credential feature,
I did not take the response of the `GitRepoConfig` API method into
account. As a direct result, the `fluxctl sync` command still exposes
the full Git URL in the logs.

This commit embeds the `git.Remote` in the `GitRemoteConfig` structure,
so that we can re-use the `SafeURL` helper of this structure in the
`fluxctl` code. To ensure the JSON representation stays the same, a
JSON struct tag has been added to the `git.Remote` URL field.

Fixes #2548