### PR TITLE
Update the automation interval flag in the chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -229,7 +229,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `gpgKeys.secretName`                              | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
 | `gpgKeys.configMapName`                           | `None`                                               | Kubernetes config map with public GPG keys the Flux daemon should import
 | `ssh.known_hosts`                                 | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
-| `registry.pollInterval`                           | `5m`                                                 | Period at which to check for updated images
+| `registry.automationInterval`                     | `5m`                                                 | Period at which to check for updated images
 | `registry.rps`                                    | `200`                                                | Maximum registry requests per second per host
 | `registry.burst`                                  | `125`                                                | Maximum number of warmer connections to remote and memcache
 | `registry.trace`                                  | `false`                                              | Output trace of image registry requests to log

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
           {{- if .Values.manifestGeneration }}
           - --manifest-generation=true
           {{- end }}
-          - --registry-poll-interval={{ .Values.registry.pollInterval }}
+          - --automation-interval={{ .Values.registry.pollInterval | default .Values.registry.automationInterval }}
           - --registry-rps={{ .Values.registry.rps }}
           - --registry-burst={{ .Values.registry.burst }}
           - --registry-trace={{ .Values.registry.trace }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -197,7 +197,7 @@ git:
 
 registry:
   # Period at which to check for updated images
-  pollInterval: "5m"
+  automationInterval: "5m"
   # Maximum registry requests per second per host
   rps: 200
   # Maximum number of warmer connections to remote and memcache


### PR DESCRIPTION
Since the logs tell me to do so:
```
Flag --registry-poll-interval has been deprecated, changed to --automation-interval, use that instead
```

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
