### PR TITLE
e2e: generate SSH secret per test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,8 @@ testdata/sidecar/sidecar-linux-amd64
 testdata/sidecar/.sidecar
 docker/fluxy-dumbconf.priv
 test/profiles
-test/bin/kubectl
-test/bin/kustomize
-test/bin/helm
-test/bin/kind
+test/bin/
+!test/bin/test-flux
 test/e2e/bats
 
 # Docs

--- a/test/e2e/10_helm_chart.bats
+++ b/test/e2e/10_helm_chart.bats
@@ -4,6 +4,7 @@ load lib/install
 load lib/poll
 
 function setup() {
+  generate_ssh_secret
   install_git_srv
   install_tiller
   install_flux_with_helm
@@ -31,5 +32,6 @@ function teardown() {
   uninstall_flux_with_helm
   uninstall_tiller
   uninstall_git_srv
+  delete_generated_ssh_secret
   kubectl delete namespace demo
 }

--- a/test/e2e/11_fluxctl_install.bats
+++ b/test/e2e/11_fluxctl_install.bats
@@ -4,6 +4,7 @@ load lib/install
 load lib/poll
 
 function setup() {
+  generate_ssh_secret
   install_git_srv
   install_flux_with_fluxctl
 }
@@ -25,5 +26,6 @@ function teardown() {
 
   uninstall_flux_with_fluxctl
   uninstall_git_srv
+  delete_generated_ssh_secret
   kubectl delete namespace demo
 }

--- a/test/e2e/fixtures/gitsrv.yaml
+++ b/test/e2e/fixtures/gitsrv.yaml
@@ -35,7 +35,7 @@ spec:
       volumes:
       - name: flux-git-deploy
         secret:
-          secretName: flux-git-deploy
+          secretName: $GIT_SECRET_NAME
       - name: git-server-data
         emptyDir: {}
 ---

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -47,11 +47,6 @@ fi
 kubectl create namespace "$FLUX_NAMESPACE"
 defer kubectl delete namespace "$FLUX_NAMESPACE"
 
-echo '>>> Creating ssh key and Git access secret'
-ssh-keygen -t rsa -N "" -f "${FIXTURES_DIR}/id_rsa"
-defer rm -f "${FIXTURES_DIR}/id_rsa" "${FIXTURES_DIR}/id_rsa.pub"
-kubectl create secret generic flux-git-deploy --namespace="${FLUX_NAMESPACE}" --from-file="${FIXTURES_DIR}/known_hosts" --from-file="${FIXTURES_DIR}/id_rsa" --from-file=identity="${FIXTURES_DIR}/id_rsa" --from-file="${FIXTURES_DIR}/id_rsa.pub"
-
 if [ "${USING_KIND}" = 'true' ]; then
   echo '>>> Loading images into the Kind cluster'
   kind --name "${KIND_CLUSTER}" load docker-image 'docker.io/fluxcd/flux:latest'


### PR DESCRIPTION
The issue with the setup before this commit surfaced while adding a
new test suite for GPG functionalities.

Due to `fluxctl install` creating a boilerplate secret with the same
name as the secret generated by `run.bash`, it was removed during the
teardown of the test suite which tests the command, as this simply
`kubectl delete -f -`s the output of `fluxctl install`.

This caused my own tests to never get past the point of booting a
new git server instance, as the secret it was trying to mount was
no longer present.

This commit adds two helper methods to `lib/install.bash`,
`generate_ssh_secret` and `delete_generated_ssh_secret` which should
be run during the setup and teardown of tests which require an SSH
key (and `known_hosts`) file to be present. Both functions accept
a parameter to control what the secret should be named, which falls
back to `flux-git-deploy`. This same behaviour has been introduced
to `install_git_srv`.