### PR TITLE
e2e: setup environment variables per test case

### DIFF
--- a/test/e2e/10_helm_chart.bats
+++ b/test/e2e/10_helm_chart.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load lib/env
 load lib/install
 load lib/poll
 
 function setup() {
+  setup_env
+  kubectl create namespace "$FLUX_NAMESPACE"
   generate_ssh_secret
   install_git_srv
   install_tiller
@@ -32,6 +35,7 @@ function teardown() {
   uninstall_flux_with_helm
   uninstall_tiller
   uninstall_git_srv
-  delete_generated_ssh_secret
-  kubectl delete namespace demo
+  kubectl delete namespace "$DEMO_NAMESPACE"
+  # This also takes care of removing the generated secret
+  kubectl delete namespace "$FLUX_NAMESPACE"
 }

--- a/test/e2e/11_fluxctl_install.bats
+++ b/test/e2e/11_fluxctl_install.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load lib/env
 load lib/install
 load lib/poll
 
 function setup() {
+  setup_env
+  kubectl create namespace "$FLUX_NAMESPACE"
   generate_ssh_secret
   install_git_srv
   install_flux_with_fluxctl
@@ -26,6 +29,7 @@ function teardown() {
 
   uninstall_flux_with_fluxctl
   uninstall_git_srv
-  delete_generated_ssh_secret
-  kubectl delete namespace demo
+  kubectl delete namespace "$DEMO_NAMESPACE"
+  # This also takes care of removing the generated secret
+  kubectl delete namespace "$FLUX_NAMESPACE"
 }

--- a/test/e2e/lib/env.bash
+++ b/test/e2e/lib/env.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+function setup_env() {
+    local flux_namespace=${1:-flux-e2e}
+    export FLUX_NAMESPACE=$flux_namespace
+
+    local demo_namespace=${2:-demo}
+    export DEMO_NAMESPACE=$demo_namespace
+
+    local flux_root_dir
+    flux_root_dir=$(git rev-parse --show-toplevel)
+    export FLUX_ROOT_DIR=$flux_root_dir
+    export E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
+    export FIXTURES_DIR="${E2E_DIR}/fixtures"
+
+    local known_hosts
+    known_hosts=$(cat "${FIXTURES_DIR}/known_hosts")
+    export KNOWN_HOSTS=$known_hosts
+
+    local gitconfig
+    gitconfig=$(cat "${FIXTURES_DIR}/gitconfig")
+    export GITCONFIG=$gitconfig
+}

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -45,13 +45,13 @@ function uninstall_flux_with_helm() {
   kubectl delete crd helmreleases.flux.weave.works > /dev/null 2>&1
 }
 
-fluxctl_install_cmd="fluxctl install --namespace ${FLUX_NAMESPACE} --git-url=ssh://git@gitsrv/git-server/repos/cluster.git --git-email=foo"
+fluxctl_install_cmd="fluxctl install --git-url=ssh://git@gitsrv/git-server/repos/cluster.git --git-email=foo"
 
 function install_flux_with_fluxctl() {
   local eol=$'\n'
   # Use the local Flux image instead of the latest release, use a poll interval of 10s
   # (to make tests quicker) and disable registry polling (to avoid overloading kind)
-  $fluxctl_install_cmd |
+  $fluxctl_install_cmd --namespace "${FLUX_NAMESPACE}" |
     sed 's%docker\.io/fluxcd/flux:.*%fluxcd/flux:latest%' |
     sed "s%--git-email=foo%--git-email=foo\\$eol        - --git-poll-interval=10s%" |
     sed "s%--git-email=foo%--git-email=foo\\$eol        - --sync-interval=10s%" |
@@ -65,8 +65,7 @@ function install_flux_with_fluxctl() {
 }
 
 function uninstall_flux_with_fluxctl() {
-  $fluxctl_install_cmd | kubectl delete -f -
-
+  $fluxctl_install_cmd --namespace "${FLUX_NAMESPACE}" | kubectl delete -f -
 }
 
 function generate_ssh_secret() {

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -5,20 +5,12 @@ set -o errexit
 # This script runs the bats tests, first ensuring there is a kubernetes cluster available,
 # with a flux namespace and a git secret ready to use
 
-# Global variables to be used in the libraries/tests
-export FLUX_NAMESPACE=flux-e2e
-FLUX_ROOT_DIR=$(git rev-parse --show-toplevel)
-export FLUX_ROOT_DIR
-export E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
-export FIXTURES_DIR="${E2E_DIR}/fixtures"
-KNOWN_HOSTS=$(cat "${FIXTURES_DIR}/known_hosts")
-export KNOWN_HOSTS
-GITCONFIG=$(cat "${FIXTURES_DIR}/gitconfig")
-export GITCONFIG
-export DEMO_NAMESPACE=demo
+# Directory paths we need to be aware of
+FLUX_ROOT_DIR="$(git rev-parse --show-toplevel)"
+E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
+CACHE_DIR="${FLUX_ROOT_DIR}/cache/$CURRENT_OS_ARCH"
 
 KIND_VERSION="v0.5.1"
-CACHE_DIR="${FLUX_ROOT_DIR}/cache/$CURRENT_OS_ARCH"
 KIND_CACHE_PATH="${CACHE_DIR}/kind-$KIND_VERSION"
 KIND_CLUSTER=flux-e2e
 USING_KIND=false
@@ -43,9 +35,6 @@ if ! kubectl version > /dev/null 2>&1; then
   USING_KIND=true
   kubectl get pods --all-namespaces
 fi
-
-kubectl create namespace "$FLUX_NAMESPACE"
-defer kubectl delete namespace "$FLUX_NAMESPACE"
 
 if [ "${USING_KIND}" = 'true' ]; then
   echo '>>> Loading images into the Kind cluster'


### PR DESCRIPTION
To ensure tests can be run individually, with as only prerequisite
a running cluster with the `fluxcd/flux` image present.

Running a single test is as simple as running:
`bats -t test/e2e/<testcase>.bats`