### PR TITLE
e2e: Add basic sync test

### DIFF
--- a/test/e2e/10_helm_chart.bats
+++ b/test/e2e/10_helm_chart.bats
@@ -32,7 +32,8 @@ function teardown() {
 
   uninstall_flux_with_helm
   uninstall_tiller
-  uninstall_git_srv
-  kubectl delete namespace "$DEMO_NAMESPACE"
+  # Removing the namespace also takes care of removing gitsrv.
   kubectl delete namespace "$FLUX_NAMESPACE"
+  # Only remove the demo workloads after Flux, so that they cannot be recreated.
+  kubectl delete namespace "$DEMO_NAMESPACE"
 }

--- a/test/e2e/10_helm_chart.bats
+++ b/test/e2e/10_helm_chart.bats
@@ -5,9 +5,7 @@ load lib/install
 load lib/poll
 
 function setup() {
-  setup_env
   kubectl create namespace "$FLUX_NAMESPACE"
-  generate_ssh_secret
   install_git_srv
   install_tiller
   install_flux_with_helm
@@ -36,6 +34,5 @@ function teardown() {
   uninstall_tiller
   uninstall_git_srv
   kubectl delete namespace "$DEMO_NAMESPACE"
-  # This also takes care of removing the generated secret
   kubectl delete namespace "$FLUX_NAMESPACE"
 }

--- a/test/e2e/11_fluxctl_install.bats
+++ b/test/e2e/11_fluxctl_install.bats
@@ -5,9 +5,7 @@ load lib/install
 load lib/poll
 
 function setup() {
-  setup_env
   kubectl create namespace "$FLUX_NAMESPACE"
-  generate_ssh_secret
   install_git_srv
   install_flux_with_fluxctl
 }
@@ -30,6 +28,5 @@ function teardown() {
   uninstall_flux_with_fluxctl
   uninstall_git_srv
   kubectl delete namespace "$DEMO_NAMESPACE"
-  # This also takes care of removing the generated secret
   kubectl delete namespace "$FLUX_NAMESPACE"
 }

--- a/test/e2e/11_fluxctl_install.bats
+++ b/test/e2e/11_fluxctl_install.bats
@@ -25,8 +25,8 @@ function teardown() {
   echo '>>> Check workload'
   kubectl -n "${DEMO_NAMESPACE}" rollout status deployment/podinfo
 
-  uninstall_flux_with_fluxctl
-  uninstall_git_srv
-  kubectl delete namespace "$DEMO_NAMESPACE"
+  # Removing the namespace also takes care of removing Flux and gitsrv.
   kubectl delete namespace "$FLUX_NAMESPACE"
+  # Only remove the demo workloads after Flux, so that they cannot be recreated.
+  kubectl delete namespace "$DEMO_NAMESPACE"
 }

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -36,7 +36,7 @@ function setup() {
   [ "$sync_tag_hash" = "$head_hash" ]
 
   # Add a change, wait for it to happen and check the sync tag again
-  sed -i '' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
+  sed -i'.bak' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
   git commit -am "Bump podinfo"
   head_hash=$(git rev-list -n 1 HEAD)
   git push

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load lib/env
+load lib/install
+load lib/poll
+load lib/defer
+
+git_ssh_cmd=""
+git_port_forward_pid=""
+
+function setup() {
+  kubectl create namespace "$FLUX_NAMESPACE"
+  # Install flux and the git server, allowing external access
+  install_git_srv flux-git-deploy git_srv_result
+  # shellcheck disable=SC2154
+  git_ssh_cmd="${git_srv_result[0]}"
+  # shellcheck disable=SC2154
+  git_port_forward_pid="${git_srv_result[1]}"
+  install_flux_with_fluxctl
+}
+
+@test "Basic sync test" {
+  # wait until flux deploys the workloads
+  poll_until_true 'workload podinfo' 'kubectl -n demo describe deployment/podinfo'
+
+  # Clone the repo and check the sync tag
+  local clone_dir
+  clone_dir="$(mktemp -d)"
+  defer rm -rf "$clone_dir"
+  export GIT_SSH_COMMAND="$git_ssh_cmd"
+  git clone -b master ssh://git@localhost/git-server/repos/cluster.git "$clone_dir"
+  cd "$clone_dir"
+  local sync_tag_hash
+  sync_tag_hash=$(git rev-list -n 1 flux)
+  head_hash=$(git rev-list -n 1 HEAD)
+  [ "$sync_tag_hash" = "$head_hash" ]
+
+  # Add a change, wait for it to happen and check the sync tag again
+  sed -i '' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
+  git commit -am "Bump podinfo"
+  head_hash=$(git rev-list -n 1 HEAD)
+  git push
+  poll_until_equals "podinfo image" "stefanprodan/podinfo:3.1.5" "kubectl get pod -n demo -l app=podinfo -o\"jsonpath={['items'][0]['spec']['containers'][0]['image']}\""
+  git pull -f --tags
+  sync_tag_hash=$(git rev-list -n 1 flux)
+  [ "$sync_tag_hash" = "$head_hash" ]
+}
+
+function teardown() {
+  uninstall_flux_with_fluxctl
+  kill "$git_port_forward_pid"
+  uninstall_git_srv
+  kubectl delete namespace "$DEMO_NAMESPACE"
+  kubectl delete namespace "$FLUX_NAMESPACE"
+}

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -37,7 +37,7 @@ function setup() {
 
   # Add a change, wait for it to happen and check the sync tag again
   sed -i'.bak' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
-  git commit -am "Bump podinfo"
+  git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -am "Bump podinfo"
   head_hash=$(git rev-list -n 1 HEAD)
   git push
   poll_until_equals "podinfo image" "stefanprodan/podinfo:3.1.5" "kubectl get pod -n demo -l app=podinfo -o\"jsonpath={['items'][0]['spec']['containers'][0]['image']}\""

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -47,9 +47,9 @@ function setup() {
 }
 
 function teardown() {
-  uninstall_flux_with_fluxctl
   kill "$git_port_forward_pid"
-  uninstall_git_srv
-  kubectl delete namespace "$DEMO_NAMESPACE"
+  # Removing the namespace also takes care of removing Flux and gitsrv.
   kubectl delete namespace "$FLUX_NAMESPACE"
+  # Only remove the demo workloads after Flux, so that they cannot be recreated.
+  kubectl delete namespace "$DEMO_NAMESPACE"
 }

--- a/test/e2e/lib/env.bash
+++ b/test/e2e/lib/env.bash
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
 
-function setup_env() {
-    local flux_namespace=${1:-flux-e2e}
-    export FLUX_NAMESPACE=$flux_namespace
-
-    local demo_namespace=${2:-demo}
-    export DEMO_NAMESPACE=$demo_namespace
-
-    local flux_root_dir
-    flux_root_dir=$(git rev-parse --show-toplevel)
-    export FLUX_ROOT_DIR=$flux_root_dir
-    export E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
-    export FIXTURES_DIR="${E2E_DIR}/fixtures"
-
-    local known_hosts
-    known_hosts=$(cat "${FIXTURES_DIR}/known_hosts")
-    export KNOWN_HOSTS=$known_hosts
-
-    local gitconfig
-    gitconfig=$(cat "${FIXTURES_DIR}/gitconfig")
-    export GITCONFIG=$gitconfig
-}
+export FLUX_NAMESPACE=flux-e2e
+export DEMO_NAMESPACE=demo
+FLUX_ROOT_DIR=$(git rev-parse --show-toplevel)
+export FLUX_ROOT_DIR
+export E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
+export FIXTURES_DIR="${E2E_DIR}/fixtures"
+KNOWN_HOSTS=$(cat "${FIXTURES_DIR}/known_hosts")
+export KNOWN_HOSTS
+GITCONFIG=$(cat "${FIXTURES_DIR}/gitconfig")
+export GITCONFIG

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -106,6 +106,7 @@ function install_git_srv() {
 
 function uninstall_git_srv() {
   local secret_name=${1:-flux-git-deploy}
-  kubectl delete -n "${FLUX_NAMESPACE}" secret "$secret_name"
+  # Silence secret deletion errors since the secret can be missing (deleted by uninstalling Flux)
+  kubectl delete -n "${FLUX_NAMESPACE}" secret "$secret_name" &> /dev/null
   kubectl delete -n "${FLUX_NAMESPACE}" -f "${E2E_DIR}/fixtures/gitsrv.yaml"
 }

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -64,7 +64,7 @@ function install_flux_with_fluxctl() {
   # Add the known hosts file manually (it's much easier than editing the manifests to add a volume)
   local flux_podname
   flux_podname=$(kubectl get pod -n "${FLUX_NAMESPACE}" -l name=flux -o jsonpath="{['items'][0].metadata.name}")
-  kubectl exec -n "${FLUX_NAMESPACE}" "${flux_podname}" -- sh -c "echo '${KNOWN_HOSTS}' > /root/.ssh/known_hosts" >&3
+  kubectl exec -n "${FLUX_NAMESPACE}" "${flux_podname}" -- sh -c "mkdir -p /root/.ssh; echo '${KNOWN_HOSTS}' > /root/.ssh/known_hosts" >&3
 }
 
 function uninstall_flux_with_fluxctl() {

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1090
+source "${E2E_DIR}/lib/defer.bash"
+
 function install_tiller() {
   if ! helm version > /dev/null 2>&1; then # only if helm isn't already installed
     kubectl --namespace kube-system create sa tiller
@@ -60,43 +63,49 @@ function install_flux_with_fluxctl() {
   kubectl -n "${FLUX_NAMESPACE}" rollout status deployment/flux
   # Add the known hosts file manually (it's much easier than editing the manifests to add a volume)
   local flux_podname
-  flux_podname=$(kubectl get pod -n flux-e2e -l name=flux -o jsonpath="{['items'][0].metadata.name}")
-  kubectl exec -n "${FLUX_NAMESPACE}" "${flux_podname}" -- sh -c "echo '${KNOWN_HOSTS}' > /root/.ssh/known_hosts"
+  flux_podname=$(kubectl get pod -n "${FLUX_NAMESPACE}" -l name=flux -o jsonpath="{['items'][0].metadata.name}")
+  kubectl exec -n "${FLUX_NAMESPACE}" "${flux_podname}" -- sh -c "echo '${KNOWN_HOSTS}' > /root/.ssh/known_hosts" >&3
 }
 
 function uninstall_flux_with_fluxctl() {
   $fluxctl_install_cmd --namespace "${FLUX_NAMESPACE}" | kubectl delete -f -
 }
 
-function generate_ssh_secret() {
+function install_git_srv() {
   local secret_name=${1:-flux-git-deploy}
+  local external_access_result_var=${2}
   local gen_dir
   gen_dir=$(mktemp -d)
 
   ssh-keygen -t rsa -N "" -f "$gen_dir/id_rsa"
+  defer rm -rf "$gen_dir"
   kubectl create secret generic "$secret_name" \
     --namespace="${FLUX_NAMESPACE}" \
     --from-file="${FIXTURES_DIR}/known_hosts" \
     --from-file="$gen_dir/id_rsa" \
     --from-file=identity="$gen_dir/id_rsa" \
     --from-file="$gen_dir/id_rsa.pub"
-  rm -rf "$gen_dir"
-  echo "$secret_name"
-}
 
-function delete_generated_ssh_secret() {
-  local secret_name=${1:-flux-git-deploy}
-  kubectl delete -n "${FLUX_NAMESPACE}" secret "$secret_name"
-}
-
-function install_git_srv() {
-  local secret_name=${1:-flux-git-deploy}
-
-  sed "s/\$GIT_SECRET_NAME/$secret_name/" <"${E2E_DIR}/fixtures/gitsrv.yaml" | kubectl apply -n "${FLUX_NAMESPACE}" -f -
-
+  sed "s/\$GIT_SECRET_NAME/$secret_name/" < "${E2E_DIR}/fixtures/gitsrv.yaml" | kubectl apply -n "${FLUX_NAMESPACE}" -f -
+  # wait for the git server to be ready
   kubectl -n "${FLUX_NAMESPACE}" rollout status deployment/gitsrv
+
+  if [ -n "$external_access_result_var" ]; then
+    local git_srv_podname
+    git_srv_podname=$(kubectl get pod -n "${FLUX_NAMESPACE}" -l name=gitsrv -o jsonpath="{['items'][0].metadata.name}")
+    coproc kubectl port-forward -n "${FLUX_NAMESPACE}" "$git_srv_podname" :22
+    local local_port
+    read -r local_port <&"${COPROC[0]}"-
+    # shellcheck disable=SC2001
+    local_port=$(echo "$local_port" | sed 's%.*:\([0-9]*\).*%\1%')
+    local ssh_cmd="ssh -o UserKnownHostsFile=/dev/null  -o StrictHostKeyChecking=no -i $gen_dir/id_rsa -p $local_port"
+    # return the ssh command needed for git, and the PID of the port-forwarding PID into a variable of choice
+    eval "${external_access_result_var}=('$ssh_cmd' '$COPROC_PID')"
+  fi
 }
 
 function uninstall_git_srv() {
+  local secret_name=${1:-flux-git-deploy}
+  kubectl delete -n "${FLUX_NAMESPACE}" secret "$secret_name"
   kubectl delete -n "${FLUX_NAMESPACE}" -f "${E2E_DIR}/fixtures/gitsrv.yaml"
 }


### PR DESCRIPTION
As part of it:

1. Implicitly set the environment when importing lib/env.bash
   (needed so that other library files can use the environment variables)
2. Allow accessing the git server (securely) through port-forwarding as
   part of install_git_srv
3. Merge installing gitsrv and creating the git ssh secret (so that we
   can reuse the underlying ssh keys for (2))

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
