### PR TITLE
fix: add --batch to gpg --import to fix secret key import in non-interactive shells

### DIFF
--- a/pkg/gpg/gpg.go
+++ b/pkg/gpg/gpg.go
@@ -64,7 +64,7 @@ func ImportKeys(src string, trustImportedKeys bool) ([]string, error) {
 }
 
 func gpgImport(path string) error {
-	cmd := exec.Command("gpg", "--import", path)
+	cmd := exec.Command("gpg", "--import", "--batch", path)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error importing key: %s", string(out))


### PR DESCRIPTION
Recently a change was made in gpg 2.2.x IIRC that causes some weird issues with respect to importing secret keys in non-interactive shells.

The fix is to simply add `--batch` to the command. That is all this PR does.