### PR TITLE
Chart: allow `git.verifySignature` to be `"false"`

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -206,9 +206,7 @@ spec:
           {{- if .Values.git.signingKey }}
           - --git-signing-key={{ .Values.git.signingKey }}
           {{- end }}
-          {{- if .Values.git.verifySignatures }}
-          - --git-verify-signatures
-          {{- end }}
+          - --git-verify-signatures={{ .Values.git.verifySignatures }}
           - --git-set-author={{ .Values.git.setAuthor }}
           - --git-poll-interval={{ .Values.git.pollInterval }}
           - --git-timeout={{ .Values.git.timeout }}


### PR DESCRIPTION
Before this commit passing a string value to `git.verifySignature`
would result in the flag being set. In some scenarios however, in my
case end-to-end testing, you may want to explicitly set it to `false`
using a string value.

This PR makes this possible, while maintaining backwards compatibility. 