### PR TITLE
e2e: Add sync failure test

### DIFF
--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -57,6 +57,7 @@ function setup() {
   sync_tag_hash=$(git rev-list -n 1 flux)
   head_hash=$(git rev-list -n 1 HEAD)
   [ "$sync_tag_hash" = "$head_hash" ]
+  podinfo_image=$(kubectl get pod -n demo -l app=podinfo -o"jsonpath={['items'][0]['spec']['containers'][0]['image']}")
 
   # Bump the image of podinfo, duplicate the resource definition (to cause a sync failure)
   # and make sure the sync doesn't go through
@@ -68,9 +69,9 @@ function setup() {
   # Wait until we find the duplicate failure in the logs
   poll_until_true "duplicate resource in Flux logs" "kubectl logs -n $FLUX_NAMESPACE -l name=flux | grep -q \"duplicate definition of 'demo:deployment/podinfo'\""
   # Make sure that the version of podinfo wasn't bumped
-  local podinfo_image
-  podinfo_image=$(kubectl get pod -n demo -l app=podinfo -o"jsonpath={['items'][0]['spec']['containers'][0]['image']}")
-  [ "$podinfo_image" = "stefanprodan/podinfo:2.1.0" ]
+  local podinfo_image_now
+  podinfo_image_now=$(kubectl get pod -n demo -l app=podinfo -o"jsonpath={['items'][0]['spec']['containers'][0]['image']}")
+  [ "$podinfo_image" = "$podinfo_image_now" ]
   # Make sure that the Flux sync tag remains untouched
   git pull -f --tags
   sync_tag_hash=$(git rev-list -n 1 flux)

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -33,8 +33,9 @@ function setup() {
   git pull -f --tags
   local sync_tag_hash
   sync_tag_hash=$(git rev-list -n 1 flux)
+  local head_hash
   head_hash=$(git rev-list -n 1 HEAD)
-  [ "$sync_tag_hash" = "$head_hash" ]
+  [ "$head_hash" = "$sync_tag_hash" ]
 
   # Add a change, wait for it to happen and check the sync tag again
   sed -i'.bak' 's%stefanprodan/podinfo:.*%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
@@ -44,7 +45,7 @@ function setup() {
   poll_until_equals "podinfo image" "stefanprodan/podinfo:3.1.5" "kubectl get pod -n demo -l app=podinfo -o\"jsonpath={['items'][0]['spec']['containers'][0]['image']}\""
   git pull -f --tags
   sync_tag_hash=$(git rev-list -n 1 flux)
-  [ "$sync_tag_hash" = "$head_hash" ]
+  [ "$head_hash" = "$sync_tag_hash" ]
 }
 
 @test "Sync fails on duplicate resource" {
@@ -55,8 +56,9 @@ function setup() {
   git pull -f --tags
   local sync_tag_hash
   sync_tag_hash=$(git rev-list -n 1 flux)
+  local head_hash
   head_hash=$(git rev-list -n 1 HEAD)
-  [ "$sync_tag_hash" = "$head_hash" ]
+  [ "$head_hash" = "$sync_tag_hash" ]
   podinfo_image=$(kubectl get pod -n demo -l app=podinfo -o"jsonpath={['items'][0]['spec']['containers'][0]['image']}")
 
   # Bump the image of podinfo, duplicate the resource definition (to cause a sync failure)
@@ -75,7 +77,7 @@ function setup() {
   # Make sure that the Flux sync tag remains untouched
   git pull -f --tags
   sync_tag_hash=$(git rev-list -n 1 flux)
-  [ "$sync_tag_hash" = "$head_hash" ]
+  [ "$head_hash" = "$sync_tag_hash" ]
 }
 
 function teardown() {

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -37,7 +37,7 @@ function setup() {
   [ "$sync_tag_hash" = "$head_hash" ]
 
   # Add a change, wait for it to happen and check the sync tag again
-  sed -i'.bak' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
+  sed -i'.bak' 's%stefanprodan/podinfo:.*%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -am "Bump podinfo"
   head_hash=$(git rev-list -n 1 HEAD)
   git push
@@ -60,7 +60,7 @@ function setup() {
 
   # Bump the image of podinfo, duplicate the resource definition (to cause a sync failure)
   # and make sure the sync doesn't go through
-  sed -i'.bak' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
+  sed -i'.bak' 's%stefanprodan/podinfo:.*%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
   cp "${clone_dir}/workloads/podinfo-dep.yaml" "${clone_dir}/workloads/podinfo-dep-2.yaml"
   git add "${clone_dir}/workloads/podinfo-dep-2.yaml"
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -am "Bump podinfo and duplicate it to cause an error"

--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -6,6 +6,7 @@ load lib/poll
 load lib/defer
 
 git_port_forward_pid=""
+clone_dir=""
 
 function setup() {
   kubectl create namespace "$FLUX_NAMESPACE"
@@ -17,18 +18,19 @@ function setup() {
   # shellcheck disable=SC2154
   git_port_forward_pid="${git_srv_result[1]}"
   install_flux_with_fluxctl
+  # Clone the repo and
+  clone_dir="$(mktemp -d)"
+  git clone -b master ssh://git@localhost/git-server/repos/cluster.git "$clone_dir"
+  # shellcheck disable=SC2164
+  cd "$clone_dir"
 }
 
 @test "Basic sync test" {
   # Wait until flux deploys the workloads
   poll_until_true 'workload podinfo' 'kubectl -n demo describe deployment/podinfo'
 
-  # Clone the repo and check the sync tag
-  local clone_dir
-  clone_dir="$(mktemp -d)"
-  defer rm -rf "$clone_dir"
-  git clone -b master ssh://git@localhost/git-server/repos/cluster.git "$clone_dir"
-  cd "$clone_dir"
+  # Check the sync tag
+  git pull -f --tags
   local sync_tag_hash
   sync_tag_hash=$(git rev-list -n 1 flux)
   head_hash=$(git rev-list -n 1 HEAD)
@@ -45,7 +47,38 @@ function setup() {
   [ "$sync_tag_hash" = "$head_hash" ]
 }
 
+@test "Sync fails on duplicate resource" {
+  # Wait until flux deploys the workloads
+  poll_until_true 'workload podinfo' 'kubectl -n demo describe deployment/podinfo'
+
+  # Check the sync tag
+  git pull -f --tags
+  local sync_tag_hash
+  sync_tag_hash=$(git rev-list -n 1 flux)
+  head_hash=$(git rev-list -n 1 HEAD)
+  [ "$sync_tag_hash" = "$head_hash" ]
+
+  # Bump the image of podinfo, duplicate the resource definition (to cause a sync failure)
+  # and make sure the sync doesn't go through
+  sed -i'.bak' 's%stefanprodan/podinfo:2.1.0%stefanprodan/podinfo:3.1.5%' "${clone_dir}/workloads/podinfo-dep.yaml"
+  cp "${clone_dir}/workloads/podinfo-dep.yaml" "${clone_dir}/workloads/podinfo-dep-2.yaml"
+  git add "${clone_dir}/workloads/podinfo-dep-2.yaml"
+  git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -am "Bump podinfo and duplicate it to cause an error"
+  git push
+  # Wait until we find the duplicate failure in the logs
+  poll_until_true "duplicate resource in Flux logs" "kubectl logs -n $FLUX_NAMESPACE -l name=flux | grep -q \"duplicate definition of 'demo:deployment/podinfo'\""
+  # Make sure that the version of podinfo wasn't bumped
+  local podinfo_image
+  podinfo_image=$(kubectl get pod -n demo -l app=podinfo -o"jsonpath={['items'][0]['spec']['containers'][0]['image']}")
+  [ "$podinfo_image" = "stefanprodan/podinfo:2.1.0" ]
+  # Make sure that the Flux sync tag remains untouched
+  git pull -f --tags
+  sync_tag_hash=$(git rev-list -n 1 flux)
+  [ "$sync_tag_hash" = "$head_hash" ]
+}
+
 function teardown() {
+  rm -rf "$clone_dir"
   # Teardown the created port-forward to gitsrv and restore Git settings.
   kill "$git_port_forward_pid"
   unset GIT_SSH_COMMAND


### PR DESCRIPTION
The test updates and duplicates a resource, making sure syncing catches the problem and no update is performed in the cluster.