### PR TITLE
Remove redundant return code

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -418,7 +418,6 @@ func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
 			continue
 		}
 	}
-	return nil
 }
 
 func (r *Repo) Refresh(ctx context.Context) error {


### PR DESCRIPTION
Under the for loop, this line of code will never be reachable.