### PR TITLE
remove replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,15 @@ module github.com/fluxcd/flux
 
 go 1.13
 
+// remove when https://github.com/docker/distribution/pull/2905 is released.
+replace github.com/docker/distribution => github.com/2opremio/distribution v0.0.0-20190419185413-6c9727e5e5de
+
 require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Masterminds/semver v1.4.2
 	github.com/aws/aws-sdk-go v1.19.11
 	github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668
-	github.com/docker/distribution v0.0.0-00010101000000-000000000000
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/fluxcd/helm-operator v1.0.0-rc2
 	github.com/ghodss/yaml v1.0.0
@@ -35,26 +38,10 @@ require (
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/yaml.v2 v2.2.2
-	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
-	k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed
-	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
+	k8s.io/api v0.0.0-20190708174958-539a33f6e817 // kubernetes-1.14.4
+	k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed // kubernetes-1.14.4
+	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d // kubernetes-1.14.4
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/helm v2.13.1+incompatible
 	k8s.io/klog v0.3.3
-)
-
-replace github.com/docker/distribution => github.com/2opremio/distribution v0.0.0-20190419185413-6c9727e5e5de
-
-// The following pin these libs to `kubernetes-1.14.4` (by initially
-// giving the version as that tag, and letting go mod fill in its idea of
-// the version).
-// The libs are thereby kept compatible with client-go v11, which is
-// itself compatible with Kubernetes 1.14.
-
-replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190708174958-539a33f6e817
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
-	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190708180123-608cd7da68f7
-	k8s.io/client-go => k8s.io/client-go v11.0.0+incompatible
-	k8s.io/component-base => k8s.io/component-base v0.0.0-20190708175518-244289f83105
 )

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+k8s.io/api v0.0.0-20190313235455-40a48860b5ab/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817 h1:V6YPTc5fSnwv7EBjx6es9VyAki/6bqK4M3ECA6WwfBk=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed h1:rCteec//ELIjZMfjIGQbVtZooyaofqDJwsmWwWKItNs=


### PR DESCRIPTION
go.mod contains many replace entries that all consumers must include to
import logic. These are cancerous and tend to make consumers builds
difficult or outright fail. All have been removed, except for the one
required by helm-operator. This entry, while retained, has been
converted into a noop and should be removed when
fluxcd/helm-operator#97 is fixed.