### PR TITLE
e2e: Test the local Flux version

### DIFF
--- a/test/e2e/fixtures/kustom/base/flux/e2e_patch.yaml
+++ b/test/e2e/fixtures/kustom/base/flux/e2e_patch.yaml
@@ -1,3 +1,7 @@
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: docker.io/fluxcd/flux:latest # test the flux version being developed on and not the latest
+                                      # release
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: --git-poll-interval=10s


### PR DESCRIPTION
https://github.com/fluxcd/flux/pull/2577 introduced a regression, ( at https://github.com/fluxcd/flux/pull/2577/files#diff-e76b06a8940cf68dbf66b91380d3dc28L58 )
causing the end-to-end tests to use the latest Flux release instead of the local version.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
