### PR TITLE
Fix patchFile-based manifest generation

### DIFF
--- a/pkg/manifests/configfile.go
+++ b/pkg/manifests/configfile.go
@@ -121,7 +121,7 @@ func (cf *ConfigFile) RelativeConfigPath() (string, error) {
 // necessary) according to the config file.
 func (cf *ConfigFile) GenerateManifests(ctx context.Context, manifests Manifests) ([]byte, error) {
 	if cf.PatchUpdated != nil {
-		finalBytes, _, _, err := cf.getGeneratedAndPatchedManifests(ctx, manifests)
+		_, finalBytes, _, err := cf.getGeneratedAndPatchedManifests(ctx, manifests)
 		return finalBytes, err
 	}
 	return cf.getGeneratedManifests(ctx, manifests, cf.CommandUpdated.Generators)
@@ -212,7 +212,7 @@ type ConfigFileCombinedExecResult struct {
 
 // -- these are helpers to support the entry points above
 
-// getGeneratedAndPatchedManifests is used to generated manifests when
+// getGeneratedAndPatchedManifests is used to generate manifests when
 // the config is patchUpdated.
 func (cf *ConfigFile) getGeneratedAndPatchedManifests(ctx context.Context, manifests Manifests) ([]byte, []byte, string, error) {
 	generatedManifests, err := cf.getGeneratedManifests(ctx, manifests, cf.PatchUpdated.Generators)

--- a/test/e2e/22_manifest_generation.bats
+++ b/test/e2e/22_manifest_generation.bats
@@ -17,7 +17,6 @@ function setup() {
 }
 
 @test "Basic sync and editing" {
-  skip # needed until https://github.com/fluxcd/flux/issues/2602 is fixed
   # Wait until flux deploys the workloads
   poll_until_true 'workload podinfo' 'kubectl -n demo describe deployment/podinfo'
 


### PR DESCRIPTION
The problem was introduced at https://github.com/fluxcd/flux/pull/2565

Also, re-enable the manifest generation e2e test, which was disabled
because of the bug fixed here.

Fixes #2602 