### PR TITLE
fix indents in the .flux.yaml reference

### DIFF
--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -156,9 +156,9 @@ In addition, `updaters` are provided with some environment variables:
 
 * `FLUX_WORKLOAD`: Workload to be updated. Its format is `<namespace>:<kind>/<name>` (e.g. `default:deployment/foo`).
   For convenience (to circumvent parsing) `FLUX_WORKLOAD` is also broken down into the following environment variables:
-        * `FLUX_WL_NS`
-        * `FLUX_WL_KIND`
-        * `FLUX_WL_NAME`
+  * `FLUX_WL_NS`
+  * `FLUX_WL_KIND`
+  * `FLUX_WL_NAME`
 * `containerImage` updaters are provided with:
   * `FLUX_CONTAINER`: Name of the container within the workload whose image needs to be updated.
   * `FLUX_IMG`: Image name which the container needs to be updated to (e.g. `nginx`).


### PR DESCRIPTION
indents of the environment variable list are broken and fixed them

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
