### PR TITLE
Support unwrapping `NotReadyError`

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -29,6 +29,8 @@ type NotReadyError struct {
 	underlying error
 }
 
+func (err NotReadyError) Unwrap() error { return err.underlying }
+
 func (err NotReadyError) Error() string {
 	return "git repo not ready: " + err.underlying.Error()
 }


### PR DESCRIPTION
This error is heavily used by the Helm operator to determine if it
can proceed with a release making use of a git source. It is however
not so easy to only get the reason of failure from the error in it's
existing form, and add our own Helm operator related context to it,
without repeating ourselves.

This commit adds the in Golang 1.13 introduced `Unwrap` method to the
error, so that the underlying error can be unwrapped from the returned
error on e.g. `Status()` calls.

https://blog.golang.org/go1.13-errors