### PR TITLE
Honor KUBE_CONFIG env. variable, if present

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -197,7 +197,11 @@ func main() {
 	fs.MarkDeprecated("registry-poll-interval", "changed to --automation-interval, use that instead")
 
 	var kubeConfig *string
-	{
+	kubeConfigEnv, hasKubeConfigEnv := os.LookupEnv("KUBE_CONFIG")
+	
+	if hasKubeConfigEnv {
+		kubeConfig = &kubeConfigEnv
+	} else {
 		// Set the default kube config
 		if home := homeDir(); home != "" {
 			kubeConfig = fs.String("kube-config", filepath.Join(home, ".kube", "config"), "the absolute path of the k8s config file.")


### PR DESCRIPTION
Whilst debugging I realised that there is no proper way to specify a custom kubernetes config location. This PR adds such a functionality so that interested users can use the `KUBE_CONFIG` environment variable as it already happens with `kubectl`. 