### PR TITLE
Fix mergeCredentials namespace reference

### DIFF
--- a/pkg/cluster/kubernetes/images.go
+++ b/pkg/cluster/kubernetes/images.go
@@ -146,7 +146,7 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 			imageCreds := make(registry.ImageCreds)
 			for _, workload := range workloads {
 				logger := log.With(c.logger, "resource", resource.MakeID(workload.GetNamespace(), kind, workload.GetName()))
-				mergeCredentials(logger.Log, c.includeImage, c.client, ns, workload.podTemplate, imageCreds, seenCreds)
+				mergeCredentials(logger.Log, c.includeImage, c.client, workload.GetNamespace(), workload.podTemplate, imageCreds, seenCreds)
 			}
 
 			// Merge creds


### PR DESCRIPTION
On certain setups, the following error appears (and the deploy is not successful?) even though the manifest is correct:

```
ts=2019-11-20T08:56:10.472306948Z caller=images.go:78 resource=:deployment/dep-product-backend err="getting secret \"regcred\" from namespace \"\": an empty namespace may not be set when a resource name is provided"
```

This issue is caused by the fact that the `ns` variable may be set to "" (meaning "all namespaces", see `meta_v1.NamespaceAll`), therefore in `mergeCredentials(...)` the "" namespace is forwarded and used for looking at the imagePullSecrets.  
  
Related commit: 1dbeff3a0a53f079523a1a31dab97003ed9ef922 . 
  
~~Please do not merge yet, I'm testing it (`nanosapp/flux:feature-namespace-regcred-fix-e1276641-wip`)~~

Seems to be fixed, ready to be merged  🚀 