### PR TITLE
fix: added support for annotation for memcached

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -18,6 +18,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+      {{- if .Values.annotations }}
+      {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "flux.name" . }}-memcached
         release: {{ .Release.Name }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -19,8 +19,8 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if .Values.annotations }}
-      {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.memcached.annotations }}
+      {{- .Values.memcached.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "flux.name" . }}-memcached

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -18,8 +18,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      annotations:
       {{- if .Values.memcached.annotations }}
+      annotations:
       {{- .Values.memcached.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Added support for annotation on the memcached pod

It would be nice to have it because since when we've added Istio then the sidecar is automatically injected into any pod that does not specify a given annotation.
So we are currently unable to remove the sidecar from the memcached pod.
