### PR TITLE
Added extraVolumes and extraVolumeMounts for Helm Operator

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -76,6 +76,9 @@ spec:
       - name: {{ .Values.helmOperator.configureRepositories.cacheVolumeName | quote }}
         emptyDir: {}
       {{- end }}
+      {{- if .Values.helmOperator.extraVolumes }}
+{{ toYaml .Values.helmOperator.extraVolumes | indent 6 }}
+      {{- end }}
       containers:
       - name: flux-helm-operator
         image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
@@ -116,6 +119,9 @@ spec:
           readOnly: true
         - name: {{ .Values.helmOperator.configureRepositories.cacheVolumeName | quote }}
           mountPath: /var/fluxd/helm/repository/cache
+        {{- end }}
+        {{- if .Values.helmOperator.extraVolumeMounts }}
+{{ toYaml .Values.helmOperator.extraVolumeMounts | indent 8 }}
         {{- end }}
         args:
         {{- if .Values.logFormat }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -83,6 +83,8 @@ helmOperator:
   annotations: {}
   tolerations: []
   affinity: {}
+  extraVolumeMounts: []
+  extraVolumes: []
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Hi,

It's possible to mount volumes on the Flux daemon but not on Helm Operator.
In my context, I proxify the GIT protocol, and I need to mount a configuration file.