### PR TITLE
Upgrading to latest memcached image which uses debian buster

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -234,7 +234,7 @@ memcached:
   enabled: true
   hostnameOverride:
   repository: memcached
-  tag: 1.5.15
+  tag: 1.5.20
   pullSecret:
   createClusterIP: true
   verbose: false

--- a/deploy/memcache-dep.yaml
+++ b/deploy/memcache-dep.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: memcached:1.5.15
+        image: memcached:1.5.20
         imagePullPolicy: IfNotPresent
         args:
         - -m 512   # Maximum memory to use, in megabytes

--- a/pkg/install/templates/memcache-dep.yaml.tmpl
+++ b/pkg/install/templates/memcache-dep.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: memcached:1.5.15
+        image: memcached:1.5.20
         imagePullPolicy: IfNotPresent
         args:
         - -m 512   # Maximum memory to use, in megabytes


### PR DESCRIPTION
Moving to latest image as debian stretch has vulnerabilities(  which our CSP keeps warning us about ) and also because it has other advantages.   