### PR TITLE
Reset switch in .flux.yaml

### DIFF
--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -41,9 +41,8 @@ target path, or in a directory _above_ it in the git repository.
  - if no `.flux.yaml` file is found, the usual behaviour of looking
    for YAML files is adopted for that target path.
 
- - a `.flux.yaml` file containing the `files` directive resets the
-   behaviour to looking for YAML files. This is explained further,
-   below.
+ - a `.flux.yaml` file containing the `scanForFiles` directive resets
+   the behaviour to looking for YAML files. This is explained below.
 
 The manifests from all the target paths -- read from YAML files or
 generated -- are combined before applying to the cluster. If
@@ -111,18 +110,18 @@ Note also that the configuration file would **not** take effect for
 `--git-path=.` (i.e., the top directory), because manifest generation
 will not look in subdirectories for a `.flux.yaml` file.
 
-### The `files` directive
+### The `scanForFiles` directive
 
-The `files` directive indicates that the target path should be treated
-as though it had _no_ `.flux.yaml` in effect. In other words, fluxd
-will look for YAML files under the directory, and update manifests
-directly by rewriting the YAML files.
+The `scanForFiles` directive indicates that the target path should be
+treated as though it had _no_ `.flux.yaml` in effect. In other words,
+fluxd will look for YAML files under the directory, and update
+manifests directly by rewriting the YAML files.
 
-Here's an example `.flux.yaml` with the `files` directive:
+Here's an example `.flux.yaml` with the `scanForFiles` directive:
 
 ```
 version: 1
-files: {}
+scanForFiles: {}
 ```
 
 (The `{}` is an empty map, which acts as a placeholder value).
@@ -135,7 +134,7 @@ In the following example, the top-level `.flux.yaml` would take effect
 for `--git-path=staging` or `--git-path=production`.
 
 But if you wanted `yamls/permissions.yaml` to be applied (as it is),
-you could put a `.flux.yaml` containing `files` in that directory, and
+you could put a `.flux.yaml` containing `scanForFiles` in that directory, and
 specify `--git-path=staging,yamls`.
 
 ```
@@ -152,7 +151,7 @@ specify `--git-path=staging,yamls`.
 │   ├── kustomization.yaml
 │   └── replicas-patch.yaml
 ├── yamls
-│   ├── .flux.yaml # (with "files" directive)
+│   ├── .flux.yaml # (with "scanForFiles" directive)
 │   └── permissions.yaml
 └── staging
     ├── flux-patch.yaml
@@ -161,9 +160,9 @@ specify `--git-path=staging,yamls`.
 
 ## How to construct a .flux.yaml file
 
-Aside from the special case of the `files` directive, `.flux.yaml`
-files come in two varieties: "patch-updated", "command-updated". These
-refer to the way in which [automated
+Aside from the special case of the `scanForFiles` directive,
+`.flux.yaml` files come in two varieties: "patch-updated",
+"command-updated". These refer to the way in which [automated
 updates](./automated-image-update.md) are applied to files in the
 repo:
 

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	github.com/weaveworks/promrus v1.2.0 // indirect
 	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
+	github.com/xeipuuv/gojsonschema v1.1.0
 	go.mozilla.org/sops/v3 v3.5.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934

--- a/pkg/manifests/configaware.go
+++ b/pkg/manifests/configaware.go
@@ -81,7 +81,7 @@ func splitConfigFilesAndRawManifestPaths(baseDir string, paths []string) ([]*Con
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot parse config file: %s", err)
 		}
-		if cf.IsJustFiles() {
+		if cf.IsScanForFiles() {
 			rawManifestPaths = append(rawManifestPaths, path)
 			continue
 		}

--- a/pkg/manifests/configaware.go
+++ b/pkg/manifests/configaware.go
@@ -81,6 +81,10 @@ func splitConfigFilesAndRawManifestPaths(baseDir string, paths []string) ([]*Con
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot parse config file: %s", err)
 		}
+		if cf.IsJustFiles() {
+			rawManifestPaths = append(rawManifestPaths, path)
+			continue
+		}
 		configFiles = append(configFiles, cf)
 	}
 

--- a/pkg/manifests/configaware_test.go
+++ b/pkg/manifests/configaware_test.go
@@ -385,11 +385,11 @@ func TestDuplicateInGenerators(t *testing.T) {
 	assert.Contains(t, err.Error(), "duplicate")
 }
 
-func TestJustFiles(t *testing.T) {
+func TestSccanForFiles(t *testing.T) {
 	// +-- config
 	//   +-- .flux.yaml (patchUpdated)
 	//   +-- rawfiles
-	//     +-- .flux.yaml (files)
+	//     +-- .flux.yaml (scanForFiles)
 	//     +-- manifest.yaml
 
 	manifestyaml := `
@@ -401,7 +401,7 @@ metadata:
 
 	config, baseDir, cleanup := setup(t, []string{filepath.Join("config", "rawfiles")},
 		config{path: "config", fluxyaml: patchUpdatedEchoConfigFile},
-		config{path: filepath.Join("config", "rawfiles"), fluxyaml: "version: 1\nfiles: {}\n"},
+		config{path: filepath.Join("config", "rawfiles"), fluxyaml: "version: 1\nscanForFiles: {}\n"},
 	)
 	defer cleanup()
 

--- a/pkg/manifests/configaware_test.go
+++ b/pkg/manifests/configaware_test.go
@@ -262,7 +262,7 @@ spec:
 
 const mistakenConf = `
 version: 1
-commandUpdated: # <-- because this is commandUpdated, patchFile is ignored
+commandUpdated:
   generators:
     - command: |
        echo "apiVersion: extensions/v1beta1
@@ -283,7 +283,6 @@ commandUpdated: # <-- because this is commandUpdated, patchFile is ignored
        kind: Namespace
        metadata:
          name: demo"
-  patchFile: patchfile.yaml
 `
 
 // This tests that when using a config with no update commands, and

--- a/pkg/manifests/configfile.go
+++ b/pkg/manifests/configfile.go
@@ -62,6 +62,12 @@ oneOf:
           type: array
           items: { '$ref': '#/definitions/command' }
       additionalProperties: false
+- required: ['version', 'files']
+  properties:
+    version: { '$ref': '#/definitions/version' }
+    files:
+      additionalProperties: false
+  additionalProperties: false
 `
 
 func mustCompileConfigSchema() *jsonschema.Schema {
@@ -90,6 +96,7 @@ type ConfigFile struct {
 	// Only one of the following should be set simultaneously
 	CommandUpdated *CommandUpdated `json:"commandUpdated,omitempty"`
 	PatchUpdated   *PatchUpdated   `json:"patchUpdated,omitempty"`
+	Files          *Files          `json:"files,omitempty"`
 
 	// These are supplied, and can't be calculated from each other
 	configPath         string // the absolute path to the .flux.yaml
@@ -136,6 +143,16 @@ type PolicyUpdater struct {
 type PatchUpdated struct {
 	Generators []Generator `json:"generators"`
 	PatchFile  string      `json:"patchFile,omitempty"`
+}
+
+// Files represents a config in which the directory should be treated
+// as containing YAML files -- in other words, the normal mode which
+// looks for YAML files, and records changes by writing them back to
+// the original file.
+//
+// This can be used as a reset switch for a `--git-path`, if there's a
+// .flux.yaml higher in the directory structure.
+type Files struct {
 }
 
 func ParseConfigFile(fileBytes []byte, result *ConfigFile) error {

--- a/pkg/manifests/configfile.go
+++ b/pkg/manifests/configfile.go
@@ -62,10 +62,10 @@ oneOf:
           type: array
           items: { '$ref': '#/definitions/command' }
       additionalProperties: false
-- required: ['version', 'files']
+- required: ['version', 'scanForFiles']
   properties:
     version: { '$ref': '#/definitions/version' }
-    files:
+    scanForFiles:
       additionalProperties: false
   additionalProperties: false
 `
@@ -96,7 +96,7 @@ type ConfigFile struct {
 	// Only one of the following should be set simultaneously
 	CommandUpdated *CommandUpdated `json:"commandUpdated,omitempty"`
 	PatchUpdated   *PatchUpdated   `json:"patchUpdated,omitempty"`
-	Files          *Files          `json:"files,omitempty"`
+	ScanForFiles   *ScanForFiles   `json:"scanForFiles,omitempty"`
 
 	// These are supplied, and can't be calculated from each other
 	configPath         string // the absolute path to the .flux.yaml
@@ -145,23 +145,23 @@ type PatchUpdated struct {
 	PatchFile  string      `json:"patchFile,omitempty"`
 }
 
-// Files represents a config in which the directory should be treated
-// as containing YAML files -- in other words, the normal mode which
-// looks for YAML files, and records changes by writing them back to
-// the original file.
+// ScanForFiles represents a config in which the directory should be
+// treated as containing YAML files -- in other words, the normal mode
+// which looks for YAML files, and records changes by writing them
+// back to the original file.
 //
 // This can be used as a reset switch for a `--git-path`, if there's a
 // .flux.yaml higher in the directory structure.
-type Files struct {
+type ScanForFiles struct {
 }
 
-// IsJustFiles returns true if the config file indicates that the
+// IsScanForFiles returns true if the config file indicates that the
 // directory should be treated as containing YAML files (i.e., should
 // act as though there was no config file in operation). This can be
 // used to reset the directive given by a .flux.yaml higher in the
 // directory structure.
-func (cf *ConfigFile) IsJustFiles() bool {
-	return cf.Files != nil
+func (cf *ConfigFile) IsScanForFiles() bool {
+	return cf.ScanForFiles != nil
 }
 
 func ParseConfigFile(fileBytes []byte, result *ConfigFile) error {

--- a/pkg/manifests/configfile.go
+++ b/pkg/manifests/configfile.go
@@ -11,8 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	jsonschema "github.com/xeipuuv/gojsonschema"
 
 	"github.com/fluxcd/flux/pkg/image"
 	"github.com/fluxcd/flux/pkg/resource"
@@ -23,15 +24,72 @@ const (
 	CommandTimeout = time.Minute
 )
 
+// This is easier to read as YAML, trust me.
+const configSchemaYAML = `
+"$schema": http://json-schema.org/draft-07/schema#
+definitions:
+  command:
+    type: object
+    required: ['command']
+  version: { const: 1 }
+type: object
+oneOf:
+- required: ['version', 'commandUpdated']
+  properties:
+    version: { '$ref': '#/definitions/version' }
+    commandUpdated:
+      required: ['generators']
+      properties:
+        generators:
+          type: array
+          items: { '$ref': '#/definitions/command' }
+        updaters:
+          type: array
+          items:
+            type: object
+            properties:
+              containerImage: { '$ref': '#/definitions/command' }
+              policy: { '$ref': '#/definitions/command' }
+      additionalProperties: false
+- required: ['version', 'patchUpdated']
+  properties:
+    version: { '$ref': '#/definitions/version' }
+    patchUpdated:
+      required: ['generators', 'patchFile']
+      properties:
+        patchFile: { type: string }
+        generators:
+          type: array
+          items: { '$ref': '#/definitions/command' }
+      additionalProperties: false
+`
+
+func mustCompileConfigSchema() *jsonschema.Schema {
+	j, err := yaml.YAMLToJSON([]byte(configSchemaYAML))
+	if err != nil {
+		panic(err)
+	}
+	sl := jsonschema.NewSchemaLoader()
+	sl.Validate = false
+	schema, err := sl.Compile(jsonschema.NewBytesLoader(j))
+	if err != nil {
+		panic(err)
+	}
+	return schema
+}
+
+var ConfigSchema = mustCompileConfigSchema()
+
 // ConfigFile holds the values necessary for generating and updating
 // manifests according to a `.flux.yaml` file. It does double duty as
 // the format for the file (to deserialise into), and the state
 // necessary for running commands.
 type ConfigFile struct {
-	Version int
+	Version int `json:"version"`
+
 	// Only one of the following should be set simultaneously
-	CommandUpdated *CommandUpdated `yaml:"commandUpdated"`
-	PatchUpdated   *PatchUpdated   `yaml:"patchUpdated"`
+	CommandUpdated *CommandUpdated `json:"commandUpdated,omitempty"`
+	PatchUpdated   *PatchUpdated   `json:"patchUpdated,omitempty"`
 
 	// These are supplied, and can't be calculated from each other
 	configPath         string // the absolute path to the .flux.yaml
@@ -45,44 +103,68 @@ type ConfigFile struct {
 // CommandUpdated represents a config in which updates are done by
 // execing commands as given.
 type CommandUpdated struct {
-	Generators []Generator
-	Updaters   []Updater
+	Generators []Generator `json:"generators"`
+	Updaters   []Updater   `json:"updaters,omitempty"`
 }
 
 // Generator is an individual command for generating manifests.
 type Generator struct {
-	Command string
+	Command string `json:"command,omitempty"`
 }
 
 // Updater gives a means for updating image refs and a means for
 // updating policy in a manifest.
 type Updater struct {
-	ContainerImage ContainerImageUpdater `yaml:"containerImage"`
-	Policy         PolicyUpdater
+	ContainerImage ContainerImageUpdater `json:"containerImage,omitempty"`
+	Policy         PolicyUpdater         `json:"policy,omitempty"`
 }
 
 // ContainerImageUpdater is a command for updating the image used by a
 // container, in a manifest.
 type ContainerImageUpdater struct {
-	Command string
+	Command string `json:"command,omitempty"`
 }
 
 // PolicyUpdater is a command for updating a policy for a manifest.
 type PolicyUpdater struct {
-	Command string
+	Command string `json:"command,omitempty"`
 }
 
 // PatchUpdated represents a config in which updates are done by
 // maintaining a patch, which is calculating from, and applied to, the
 // generated manifests.
 type PatchUpdated struct {
-	Generators []Generator
-	PatchFile  string `yaml:"patchFile"`
+	Generators []Generator `json:"generators"`
+	PatchFile  string      `json:"patchFile,omitempty"`
+}
+
+func ParseConfigFile(fileBytes []byte, result *ConfigFile) error {
+	// The file contents are unmarshaled into a map so that we will
+	// see any extraneous fields. This is important, for example, for
+	// detecting when someone's made a commandUpdated config but
+	// mistakenly included a patchFile, thinking it will work.
+	var intermediate map[string]interface{}
+	if err := yaml.Unmarshal(fileBytes, &intermediate); err != nil {
+		return fmt.Errorf("cannot parse: %s", err)
+	}
+	validation, err := ConfigSchema.Validate(jsonschema.NewGoLoader(intermediate))
+	if err != nil {
+		return fmt.Errorf("cannot validate: %s", err)
+	}
+	if !validation.Valid() {
+		errs := ""
+		for _, e := range validation.Errors() {
+			errs = errs + "\n" + e.String()
+		}
+		return fmt.Errorf("config file is not valid: %s", errs)
+	}
+
+	return yaml.Unmarshal(fileBytes, result)
 }
 
 // NewConfigFile constructs a ConfigFile for the relative gitPath,
-// from the config file at the absolute path configPath, with the absolute
-// workingDir.
+// from the config file at the absolute path configPath, with the
+// absolute workingDir.
 func NewConfigFile(gitPath, configPath, workingDir string) (*ConfigFile, error) {
 	result := &ConfigFile{
 		configPath:         configPath,
@@ -100,20 +182,8 @@ func NewConfigFile(gitPath, configPath, workingDir string) (*ConfigFile, error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot read: %s", err)
 	}
-	if err := yaml.Unmarshal(fileBytes, result); err != nil {
-		return nil, fmt.Errorf("cannot parse: %s", err)
-	}
 
-	switch {
-	case result.Version != 1:
-		return nil, errors.New("incorrect version, only version 1 is supported for now")
-	case (result.CommandUpdated != nil && result.PatchUpdated != nil) ||
-		(result.CommandUpdated == nil && result.PatchUpdated == nil):
-		return nil, errors.New("a single commandUpdated or patchUpdated entry must be defined")
-	case result.PatchUpdated != nil && result.PatchUpdated.PatchFile == "":
-		return nil, errors.New("patchUpdated's patchFile cannot be empty")
-	}
-	return result, nil
+	return result, ParseConfigFile(fileBytes, result)
 }
 
 // -- entry points for using a config file to generate or update manifests

--- a/pkg/manifests/configfile.go
+++ b/pkg/manifests/configfile.go
@@ -155,6 +155,15 @@ type PatchUpdated struct {
 type Files struct {
 }
 
+// IsJustFiles returns true if the config file indicates that the
+// directory should be treated as containing YAML files (i.e., should
+// act as though there was no config file in operation). This can be
+// used to reset the directive given by a .flux.yaml higher in the
+// directory structure.
+func (cf *ConfigFile) IsJustFiles() bool {
+	return cf.Files != nil
+}
+
 func ParseConfigFile(fileBytes []byte, result *ConfigFile) error {
 	// The file contents are unmarshaled into a map so that we will
 	// see any extraneous fields. This is important, for example, for

--- a/pkg/manifests/configfile_test.go
+++ b/pkg/manifests/configfile_test.go
@@ -26,6 +26,14 @@ version: 1
 patchUpdated:
   generators: []
 `,
+		"more than one": `
+version: 1
+patchUpdated:
+  generators: []
+  patchFile: patch.yaml
+commandUpdated:
+  generators: []
+`,
 
 		"duff generator": `
 version: 1
@@ -60,6 +68,11 @@ version: 1
 patchUpdated:
   generators: []
   patchFile: foo.yaml
+`,
+
+		"minimal files (the only kind)": `
+version: 1
+files: {}
 `,
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/manifests/configfile_test.go
+++ b/pkg/manifests/configfile_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	//	jsonschema "github.com/xeipuuv/gojsonschema"
 
 	"github.com/fluxcd/flux/pkg/resource"
 )
@@ -72,7 +71,7 @@ patchUpdated:
 
 		"minimal files (the only kind)": `
 version: 1
-files: {}
+scanForFiles: {}
 `,
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -84,7 +83,7 @@ files: {}
 
 const justFilesConfigFile = `
 version: 1
-files: {}
+scanForFiles: {}
 `
 
 func TestJustFileDirective(t *testing.T) {
@@ -92,7 +91,7 @@ func TestJustFileDirective(t *testing.T) {
 	err := ParseConfigFile([]byte(justFilesConfigFile), &cf)
 	assert.NoError(t, err)
 
-	assert.True(t, cf.IsJustFiles())
+	assert.True(t, cf.IsScanForFiles())
 }
 
 const patchUpdatedConfigFile = `---
@@ -109,7 +108,7 @@ func TestParsePatchUpdatedConfigFile(t *testing.T) {
 	if err := ParseConfigFile([]byte(patchUpdatedConfigFile), &cf); err != nil {
 		t.Fatal(err)
 	}
-	assert.False(t, cf.IsJustFiles())
+	assert.False(t, cf.IsScanForFiles())
 	assert.NotNil(t, cf.PatchUpdated)
 	assert.Nil(t, cf.CommandUpdated)
 	assert.Equal(t, 1, cf.Version)
@@ -140,7 +139,7 @@ func TestParseCmdUpdatedConfigFile(t *testing.T) {
 	if err := ParseConfigFile([]byte(echoCmdUpdatedConfigFile), &cf); err != nil {
 		t.Fatal(err)
 	}
-	assert.False(t, cf.IsJustFiles())
+	assert.False(t, cf.IsScanForFiles())
 	assert.NotNil(t, cf.CommandUpdated)
 	assert.Nil(t, cf.PatchUpdated)
 	assert.Equal(t, 1, cf.Version)

--- a/pkg/manifests/configfile_test.go
+++ b/pkg/manifests/configfile_test.go
@@ -82,6 +82,19 @@ files: {}
 	}
 }
 
+const justFilesConfigFile = `
+version: 1
+files: {}
+`
+
+func TestJustFileDirective(t *testing.T) {
+	var cf ConfigFile
+	err := ParseConfigFile([]byte(justFilesConfigFile), &cf)
+	assert.NoError(t, err)
+
+	assert.True(t, cf.IsJustFiles())
+}
+
 const patchUpdatedConfigFile = `---
 version: 1
 patchUpdated:
@@ -96,6 +109,7 @@ func TestParsePatchUpdatedConfigFile(t *testing.T) {
 	if err := ParseConfigFile([]byte(patchUpdatedConfigFile), &cf); err != nil {
 		t.Fatal(err)
 	}
+	assert.False(t, cf.IsJustFiles())
 	assert.NotNil(t, cf.PatchUpdated)
 	assert.Nil(t, cf.CommandUpdated)
 	assert.Equal(t, 1, cf.Version)
@@ -126,6 +140,7 @@ func TestParseCmdUpdatedConfigFile(t *testing.T) {
 	if err := ParseConfigFile([]byte(echoCmdUpdatedConfigFile), &cf); err != nil {
 		t.Fatal(err)
 	}
+	assert.False(t, cf.IsJustFiles())
 	assert.NotNil(t, cf.CommandUpdated)
 	assert.Nil(t, cf.PatchUpdated)
 	assert.Equal(t, 1, cf.Version)

--- a/pkg/manifests/rawfiles.go
+++ b/pkg/manifests/rawfiles.go
@@ -17,6 +17,8 @@ type rawFiles struct {
 	manifests Manifests
 }
 
+// NewRawFiles constructs a `Store` that assumes the provided
+// directories contain plain YAML files
 func NewRawFiles(baseDir string, paths []string, manifests Manifests) *rawFiles {
 	return &rawFiles{
 		baseDir:   baseDir,


### PR DESCRIPTION
Briefly: let people reset the processing rules in `.flux.yaml`, so you can have a `.flux.yaml` at the top of the git repo, but switch that off for a particular `--git-path`.

(At present this is branched from another PR, because I will need to write a bit of documentation about this new thing, and better to do so in revised docs)