### PR TITLE
Chart: Add support for annotations in the service account

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -204,6 +204,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `rbac.pspEnabled`                                 | `false`                                              | If `true`, create and use a restricted pod security policy for Flux pod(s)
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
+| `serviceAccount.annotations`                      | ``                                                   | Additional Service Account annotations
 | `clusterRole.create`                              | `true`                                               | If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
 | `service.port`                                    | `3030`                                               | Service port to be used

--- a/chart/flux/templates/serviceaccount.yaml
+++ b/chart/flux/templates/serviceaccount.yaml
@@ -8,4 +8,7 @@ metadata:
     chart: {{ template "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -100,6 +100,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Annotations for the Service Account
+  annotations: {}
 
 # If create is `false` and no name is given, Flux and the Helm
 # Operator will be restricted to the namespace where they are


### PR DESCRIPTION
This PR adds support for annotations in the service account. This is very useful for injecting Workload Identity in GKE clusters which can be needed for automated deployments based on image tags pushed to GCR.

Fixes: #2379 