### PR TITLE
Fix link in troubleshooting docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ explain workarounds.
 If you notice that Flux takes tens of seconds or minutes to get
 through each sync, while you can apply the same manifests very quickly
 by hand, you may be running into this issue:
-https://github.com/fluxcd/flux/issues/1422
+[fluxcd/flux#1422](https://github.com/fluxcd/flux/issues/1422).
 
 Briefly, the problem is that mounting a volume into `$HOME/.kube`
 effectively disables `kubectl`'s caching, which makes it much much


### PR DESCRIPTION
The linked issue #1422 is not rendered in Read the docs as a link.

https://docs.fluxcd.io/en/stable/troubleshooting.html#flux-is-taking-a-long-time-to-apply-manifests-when-it-syncs

This change fixes the rendering to follow the `[fluxcd/flux#number]` format used
else where in the docs.
