### PR TITLE
Propagate uppercase proxy env variables to git

### DIFF
--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -26,8 +26,9 @@ var exemptedTraceCommands = []string{
 
 // Env vars that are allowed to be inherited from the OS
 var allowedEnvVars = []string{
-	// these are for people using (no) proxies
-	"http_proxy", "https_proxy", "no_proxy", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "GIT_PROXY_COMMAND",
+	// these are for people using (no) proxies. Git follows the curl conventions, so HTTP_PROXY
+	// is intentionally missing
+	"http_proxy", "https_proxy", "no_proxy", "HTTPS_PROXY", "NO_PROXY", "GIT_PROXY_COMMAND",
 	// these are needed for GPG to find its files
 	"HOME", "GNUPGHOME",
 	// these for the git-secrets helper

--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -27,7 +27,7 @@ var exemptedTraceCommands = []string{
 // Env vars that are allowed to be inherited from the OS
 var allowedEnvVars = []string{
 	// these are for people using (no) proxies
-	"http_proxy", "https_proxy", "no_proxy", "GIT_PROXY_COMMAND",
+	"http_proxy", "https_proxy", "no_proxy", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "GIT_PROXY_COMMAND",
 	// these are needed for GPG to find its files
 	"HOME", "GNUPGHOME",
 	// these for the git-secrets helper


### PR DESCRIPTION
Only supporting the lowercase ones is confusing for the end users.
