### PR TITLE
docs: Add early link pointing to kustomize example

### DIFF
--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -5,6 +5,9 @@ instead of having to include them in your git repo as YAML files. For
 example, you can use `kustomize` to patch a common set of resources to
 suit a particular environment.
 
+> Note: For a full, self-contained example of Flux generating manifests
+> with `kustomize` you can go to [https://github.com/fluxcd/flux-kustomize-example](https://github.com/fluxcd/flux-kustomize-example)
+
 Manifest generation is controlled by the flags given to `fluxd`, and
 `.flux.yaml` files in your git repo.
 


### PR DESCRIPTION
Now that the https://github.com/weaveworks/flux-kustomize-example has been migrated to the fluxcd org it makes sense to add the link in the documentation.

Most users are interested in Kustomize, so I think it makes sense to place the link early in the `.flux.yaml` documentation.