### PR TITLE
Add a ServiceMonitor template to the chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -261,6 +261,10 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `memcached.tolerations`                           | `[]`                                                 | Tolerations properties for the memcached deployment
 | `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
+| `prometheus.serviceMonitor.create`                | `false`                                              | Set to true if using the Prometheus Operator
+| `prometheus.serviceMonitor.interval`              | ``                                                   | Interval at which metrics should be scraped
+| `prometheus.serviceMonitor.namespace`             | ``                                                   | The namespace where the ServiceMonitor is deployed
+| `prometheus.serviceMonitor.additionalLabels`      | `{}`                                                 | Additional labels to add to the ServiceMonitor
 | `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](/docs/references/garbagecollection.md))
 | `syncGarbageCollection.dry`                       | `false`                                              | If enabled, fluxd won't delete any resources, but log the garbage collection output (see [garbage collection](/docs/references/garbagecollection.md))
 | `manifestGeneration`                              | `false`                                              | If enabled, fluxd will look for `.flux.yaml` and run Kustomize or other manifest generators

--- a/chart/flux/templates/servicemonitor.yaml
+++ b/chart/flux/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.prometheus.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.prometheus.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- with .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: http
+    honorLabels: true
+    {{- with .Values.prometheus.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "flux.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -295,6 +295,13 @@ extraEnvs: []
 
 prometheus:
   enabled: false
+  serviceMonitor:
+    # Enables ServiceMonitor creation for the Prometheus Operator
+    create: false
+    interval:
+    scrapeTimeout:
+    namespace:
+    additionalLabels: {}
 
 syncGarbageCollection:
   enabled: false


### PR DESCRIPTION
Hey there 👋

This adds a [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/running-exporters.md) template to integrate with the [Prometheus Operator](https://github.com/coreos/prometheus-operator).
I'm about to do the same on [fluxcd/helm-operator](https://github.com/fluxcd/helm-operator), but I'd like to get your feedback here before proceeding.