### PR TITLE
Update docs on annotations in HelmReleases

### DIFF
--- a/docs/references/helm-operator-integration.md
+++ b/docs/references/helm-operator-integration.md
@@ -91,14 +91,14 @@ alias overrules a detected image.
 The following annotations are available, and `repository.fluxcd.io`
 is required for any of these to take effect.
 
-| Annotation                         |                  | Required? |
+| Annotation                         | Value            | Required? |
 |------------------------------------|------------------|   :---:   |
 | **`repository.fluxcd.io/<alias>`** | `sub.repo`       |     ✅    |
 | `registry.fluxcd.io/<alias>`       | `sub.reg`        |           |
 | `tag.fluxcd.io/<alias>`            | `sub.tag`        |           |
 | `filter.fluxcd.io/<alias>`         | `glob: master-*` |           |
 
-Two images specified in a `HelmRelease` as an example:
+The following example `HelmRelease` specifies two images:
 
 ```yaml
 metadata:
@@ -106,7 +106,7 @@ metadata:
     # image and tag
     repository.fluxcd.io/app: appImage
     tag.fluxcd.io/app: appTag
-    filter.tag/app: 'glob: *'
+    filter.fluxcd.io/app: 'glob: *'
     # nested image with registry and tag
     registry.fluxcd.io/submarine: sub.marinesystem.reg
     repository.fluxcd.io/submarine: sub.marinesystem.img
@@ -125,7 +125,7 @@ spec:
         tag: version
 ```
 
-#### Filters (deprecated)
+#### Filters
 
 You can use the [same annotations](fluxctl.md) in
 the `HelmRelease` as you would for a Deployment or other workload,
@@ -142,7 +142,7 @@ kind: HelmRelease
 metadata:
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.chart-image: semver:~4.0
+    filter.fluxcd.io/chart-image: semver:~4.0
 spec:
   values:
     image:
@@ -157,8 +157,8 @@ kind: HelmRelease
 metadata:
   annotations:
     fluxcd.io/automated: "true"
-    fluxcd.io/tag.prometheus: semver:~2.3
-    fluxcd.io/tag.alertmanager: glob:v0.15.*
+    filter.fluxcd.io/prometheus: semver:~2.3
+    filter.fluxcd.io/alertmanager: glob:v0.15.*
     filter.fluxcd.io/nats: regex:^0.6.*
 spec:
   values:

--- a/docs/references/helm-operator-integration.md
+++ b/docs/references/helm-operator-integration.md
@@ -64,7 +64,7 @@ values:
 These can appear at the top level (immediately under `values:`), or in
 a subsection (under a key, itself under `values:`). Other values
 may be mixed in arbitrarily. Here's an example of a values section
-that specifies two images, along with some other configuration:
+that specifies two images:
 
 ```yaml
 values:
@@ -88,15 +88,15 @@ If Flux does not automatically detect your image, it is possible to
 map the image paths by alias with YAML dot notation annotations. An
 alias overrules a detected image.
 
-The following annotations are available, you need to at least specify
-the `repository.fluxcd.io` annotation:
+The following annotations are available, and `repository.fluxcd.io`
+is required for any of these to take effect.
 
-| Annotation                    |                  |
-|-------------------------------|------------------|
-|`registry.fludcd.io/<alias>`   | `sub.reg`        |
-| `repository.fluxcd.io/<alias>`| `sub.repo`       |
-| `tag.fluxcd.io/<alias>`       | `sub.tag`        |
-| `filter.fluxcd.io/<alias>`    | `glob: master-*` |
+| Annotation                         |                  | Required? |
+|------------------------------------|------------------|   :---:   |
+| **`repository.fluxcd.io/<alias>`** | `sub.repo`       |     ✅    |
+| `registry.fluxcd.io/<alias>`       | `sub.reg`        |           |
+| `tag.fluxcd.io/<alias>`            | `sub.tag`        |           |
+| `filter.fluxcd.io/<alias>`         | `glob: master-*` |           |
 
 Two images specified in a `HelmRelease` as an example:
 
@@ -125,7 +125,7 @@ spec:
         tag: version
 ```
 
-#### Filter
+#### Filters (deprecated)
 
 You can use the [same annotations](fluxctl.md) in
 the `HelmRelease` as you would for a Deployment or other workload,


### PR DESCRIPTION
Clearly indicate that the `repository.fluxcd.io/<alias>` annotation is required, and mark the Filter section as deprecated: @2opremio [indicated](https://github.com/fluxcd/flux/issues/2663#issuecomment-562667083) that the `fluxcd.io/tag.chart-image` annotation is "a legacy and alternative way to supply a filter".

Fixes #2663.
