### PR TITLE
e2e: Fix shfmt error code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ SHFMT_WRITE_CMD := test/bin/shfmt -i 2 -sr -w
 lint-e2e: test/bin/shfmt test/bin/shellcheck
 	@# shfmt is not compatible with .bats files, so we preprocess them to turn '@test's into functions
 	for I in $(E2E_BATS_FILES); do \
-	  ( cat "$$I" | sed 's%@test.*%test() {%' | $(SHFMT_DIFF_CMD) ) || ( echo "Please correct the diff for file $$I"; exit 1 ); \
+	  ( cat "$$I" | sed 's%@test.*%test() {%' | $(SHFMT_DIFF_CMD) ) || { echo "Please correct the diff for file $$I"; exit 1; }; \
 	done
 	$(SHFMT_DIFF_CMD) $(E2E_BASH_FILES) || ( echo "Please run '$(SHFMT_WRITE_CMD) $(E2E_BASH_FILES)'"; exit 1 )
 	test/bin/shellcheck $(E2E_BASH_FILES) $(E2E_BATS_FILES)


### PR DESCRIPTION
Using parenthesis (`for ...; do ( foo; exit 1 ); done`) causes an error code in a subshell
but doesn't stop the loop.

Using braces ( `for ...; do { foo; exit 1; }; done`) groups the commands and also
exits the loop, because it doesn't execute in a subshell.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
