### PR TITLE
Run manifest image update unit tests in parallel

### DIFF
--- a/pkg/cluster/kubernetes/update_test.go
+++ b/pkg/cluster/kubernetes/update_test.go
@@ -76,11 +76,13 @@ func TestWorkloadContainerUpdates(t *testing.T) {
 		{"initContainer", case15resource, case15containers, case15image, case15, case15out, emptyContainerImageMap},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			switch c.imageAnnotations {
+			localC := c // to avoid races between the parallel tests
+			t.Parallel()
+			switch localC.imageAnnotations {
 			case emptyContainerImageMap:
-				testUpdateWorkloadContainer(t, c)
+				testUpdateWorkloadContainer(t, localC)
 			default:
-				testUpdateWorkloadImagePath(t, c)
+				testUpdateWorkloadImagePath(t, localC)
 			}
 		})
 	}


### PR DESCRIPTION
I previously disabled parallel tests in 7d9e02dac62b331c04915d540e6fd42e96e2c308 thinking it would fix the flaky unit tests in CircleCI.
    
Parallelization wasn't the culprit. On the way I also found out that tests were not really running in parallel due to `t.Parallel()` being called after the test is run.

Follow up from #2674 , #2672 and #1507