### PR TITLE
Pseudo randomize push check tag

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -15,7 +15,7 @@ const (
 	defaultInterval = 5 * time.Minute
 	defaultTimeout  = 20 * time.Second
 
-	CheckPushTag = "flux-write-check"
+	CheckPushTagPrefix = "flux-write-check"
 )
 
 var (


### PR DESCRIPTION
When multiple Flux instances are synchronizing with the same repository
but different branches, and the upstream has some latency, they get
confused about the write check they are performing due to the tag
being overwritten with a commit hash that does not belong to the branch
they are synchronzing with.

This commit pseudo randomizes the tag used to check if we can write to
the upstream repository and removes the `--force` options from the tag
and push commands so that the tag is never accidentally overwritten and
multiple instances no longer get in each other's way.

Fixes #2683 