### PR TITLE
e2e: poll for sync tag update

### DIFF
--- a/test/e2e/12_sync.bats
+++ b/test/e2e/12_sync.bats
@@ -45,8 +45,7 @@ function setup() {
   git push >&3
   poll_until_equals "podinfo image" "stefanprodan/podinfo:3.1.5" "kubectl get pod -n demo -l app=podinfo -o\"jsonpath={['items'][0]['spec']['containers'][0]['image']}\""
   git pull -f --tags
-  sync_tag_hash=$(git rev-list -n 1 flux)
-  [ "$head_hash" = "$sync_tag_hash" ]
+  poll_until_equals "sync tag" "$head_hash" "git rev-list -n 1 flux"
 }
 
 @test "Sync fails on duplicate resource" {


### PR DESCRIPTION
This ensures multiple attempts are made before bailing, as it can
take some time for Flux to push the tag after applying the change
to the cluster.

Addresses part of #2672