### PR TITLE
Upgrade Kind to v0.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
       - run: make check-generated
       - run: make all
-      - run: make e2e
+      - run: E2E_KIND_CLUSTER_NUM=4 make e2e
       - run: make test-docs
       - save_cache:
           key: cache-{{ checksum "Makefile" }}

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ TEST_FLAGS?=
 BATS_COMMIT := 3a1c2f28be260f8687ff83183cef4963faabedd6
 SHELLCHECK_VERSION := 0.7.0
 SHFMT_VERSION := 2.6.4
+HELM_VERSION := 2.16.0
 
 include docker/kubectl.version
 include docker/kustomize.version
-include docker/helm.version
 include docker/sops.version
 
 # NB default target architecture is amd64. If you would like to try the
@@ -121,10 +121,9 @@ cache/%/kustomize-$(KUSTOMIZE_VERSION): docker/kustomize.version
 	curl --fail -L -o $@ "https://github.com/kubernetes-sigs/kustomize/releases/download/v$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_`echo $* | tr - _`"
 	[ $* != "linux-amd64" ] || echo "$(KUSTOMIZE_CHECKSUM)  $@" | shasum -a 256 -c
 
-cache/%/helm-$(HELM_VERSION): docker/helm.version
+cache/%/helm-$(HELM_VERSION):
 	mkdir -p cache/$*
 	curl --fail -L -o cache/$*/helm-$(HELM_VERSION).tar.gz "https://storage.googleapis.com/kubernetes-helm/helm-v$(HELM_VERSION)-$*.tar.gz"
-	[ $* != "linux-$(ARCH)" ] || echo "$(HELM_CHECKSUM_$(ARCH))  cache/$*/helm-$(HELM_VERSION).tar.gz" | shasum -a 256 -c
 	tar -m -C ./cache -xzf cache/$*/helm-$(HELM_VERSION).tar.gz $*/helm
 	mv cache/$*/helm $@
 

--- a/docker/helm.version
+++ b/docker/helm.version
@@ -1,8 +1,0 @@
-# NB Helm clients will refuse to play with Tiller that is older. 2.8.2
-# is the first release that had checksums; but 2.9.1 appears the first
-# that reliably supports authenticating against chart repos, so that
-# wins.
-HELM_VERSION=2.13.0
-HELM_CHECKSUM_amd64=15eca6ad225a8279de80c7ced42305e24bc5ac60bb7d96f2d2fa4af86e02c794
-HELM_CHECKSUM_arm=adf1242eca171ba21847e621ce9fbdbb3dd2aa35ac8532fb05519b1b49fd4456
-HELM_CHECKSUM_arm64=afb51c43ed83fe8bac62f7e47872019cf1c0d8a1927d69fb963959c6accc77b5

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -31,10 +31,6 @@ function install_kind() {
 
 # Create multiple Kind clusters and run jobs in parallel?
 # Let users specify how many, e.g. with E2E_KIND_CLUSTER_NUM=3 make e2e
-if [ -n "$CI" ]; then
-  # Use four Kind clusters when running the tests in CircleCI
-  E2E_KIND_CLUSTER_NUM=4
-fi
 E2E_KIND_CLUSTER_NUM=${E2E_KIND_CLUSTER_NUM:-1}
 
 # Check if there is a kubernetes cluster running, otherwise use Kind

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -10,7 +10,7 @@ FLUX_ROOT_DIR="$(git rev-parse --show-toplevel)"
 E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
 CACHE_DIR="${FLUX_ROOT_DIR}/cache/$CURRENT_OS_ARCH"
 
-KIND_VERSION="v0.5.1"
+KIND_VERSION="v0.6.1"
 KIND_CACHE_PATH="${CACHE_DIR}/kind-$KIND_VERSION"
 KIND_CLUSTER_PREFIX=flux-e2e
 BATS_EXTRA_ARGS=""
@@ -42,11 +42,13 @@ if ! kubectl version > /dev/null 2>&1; then
   install_kind
 
   echo '>>> Creating Kind Kubernetes cluster(s)'
-  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
+  KIND_CONFIG_PREFIX="${HOME}/.kube/kind-config-${KIND_CLUSTER_PREFIX}"
+  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
   for I in $(seq 1 "${E2E_KIND_CLUSTER_NUM}"); do
     defer kind --name "${KIND_CLUSTER_PREFIX}-${I}" delete cluster > /dev/null 2>&1 || true
+    defer rm -rf "${KIND_CONFIG_PREFIX}-${I}"
     # Wire tests with the right cluster based on their BATS_JOB_SLOT env variable
-    eval export KUBECONFIG_SLOT_"${I}"="$(kind --name="${KIND_CLUSTER_PREFIX}-${I}" get kubeconfig-path)"
+    eval export "KUBECONFIG_SLOT_${I}=${KIND_CONFIG_PREFIX}-${I}"
   done
 
   echo '>>> Loading images into the Kind cluster(s)'


### PR DESCRIPTION
to see if it helps with the flakey end-to-end test seen in #2685 

The upgrade is not merely a version bump because:

1. The way in which Kind stores its configuration has changed since version 0.6.0, see kubernetes-sigs/kind#1060
2. The Helm version we were installing wasn't compatible with the Kubernetes version provided by Kind.

I also sneaked in a change to make the number of clusters created in CircleCI explicit.

Addresses part of #2672 