### PR TITLE
Added hostAliases to deployment template

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -268,6 +268,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](/docs/references/garbagecollection.md))
 | `syncGarbageCollection.dry`                       | `false`                                              | If enabled, fluxd won't delete any resources, but log the garbage collection output (see [garbage collection](/docs/references/garbagecollection.md))
 | `manifestGeneration`                              | `false`                                              | If enabled, fluxd will look for `.flux.yaml` and run Kustomize or other manifest generators
+| `hostAliases`                                     | `{}`                                                 | Additional hostAliases to add to the Flux pod(s). See <https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/>
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -263,6 +263,10 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases |indent 8 }}
+{{- end }}
 {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 8}}
 {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -251,3 +251,14 @@ initContainers: {}
 
 # Additional containers to be added to the flux pod.
 extraContainers: []
+
+# Host aliases to be added to the Flux pod - see < - ip: <https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/>
+hostAliases: {}
+# - ip: "127.0.0.1"
+#    hostnames:
+#    - "foo.local"
+#    - "bar.local"
+#  - ip: "10.1.2.3"
+#    hostnames:
+#    - "foo.remote"
+#    - "bar.remote"


### PR DESCRIPTION
This PR affects the Helm chart.
Whilst trying to use Flux in a specific environment, I have the issue where the Flux pod cannot resolve the gitlab instance fqdn.  This is a networking challenge of my own to fix at some point but I can envisage other people having similar problems.
Since Kubernetes allows for specifying hostAliases in pod specs (https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/), it makes sense that we should be able to pass that through in the Helm chart.