### PR TITLE
Production users: added B3i

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ container images and config changes are propagated to the cluster.
 - [Apester](https://apester.com)
 - [ArangoDB Oasis](https://arangodb.com/managed-service)
 - [Avisi](https://avisi.nl)
+- [B3i](https://b3i.tech/)
 - [Babylon Health](https://www.babylonhealth.com/)
 - [bimspot](https://bimspot.io)
 - [Canva](https://www.canva.com/)


### PR DESCRIPTION
Just adding a user of Flux in production to the readme list.
We have been running Flux across our systems at B3i for most of the year.