### PR TITLE
Add context option to fluxctl

### DIFF
--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadAutomateOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Workload namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to automate")
 
 	// Deprecated
@@ -50,10 +50,11 @@ func (opts *workloadAutomateOpts) RunE(cmd *cobra.Command, args []string) error 
 	case opts.controller != "":
 		opts.workload = opts.controller
 	}
+	ns := getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
 	policyOpts := &workloadPolicyOpts{
 		rootOpts:   opts.rootOpts,
 		outputOpts: opts.outputOpts,
-		namespace:  opts.namespace,
+		namespace:  ns,
 		workload:   opts.workload,
 		cause:      opts.cause,
 		automate:   true,

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadDeautomateOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Workload namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to deautomate")
 
 	// Deprecated
@@ -50,10 +50,11 @@ func (opts *workloadDeautomateOpts) RunE(cmd *cobra.Command, args []string) erro
 	case opts.controller != "":
 		opts.workload = opts.controller
 	}
+	ns := getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
 	policyOpts := &workloadPolicyOpts{
 		rootOpts:   opts.rootOpts,
 		outputOpts: opts.outputOpts,
-		namespace:  opts.namespace,
+		namespace:  ns,
 		workload:   opts.workload,
 		cause:      opts.cause,
 		deautomate: true,

--- a/cmd/fluxctl/install_cmd.go
+++ b/cmd/fluxctl/install_cmd.go
@@ -46,7 +46,7 @@ fluxctl install --git-url 'git@github.com:<your username>/flux-get-started' | ku
 		"Tell flux it has readonly access to the repo")
 	cmd.Flags().BoolVar(&opts.ManifestGeneration, "manifest-generation", false,
 		"Whether to enable manifest generation")
-	cmd.Flags().StringVar(&opts.Namespace, "namespace", getKubeConfigContextNamespace("default"),
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", "",
 		"Cluster namespace where to install flux")
 	cmd.Flags().StringVarP(&opts.outputDir, "output-dir", "o", "", "a directory in which to write individual manifests, rather than printing to stdout")
 
@@ -64,6 +64,7 @@ func (opts *installOpts) RunE(cmd *cobra.Command, args []string) error {
 	if opts.GitEmail == "" {
 		return fmt.Errorf("please supply a valid --git-email argument")
 	}
+	opts.TemplateParameters.Namespace = getKubeConfigContextNamespaceOrDefault(opts.Namespace, "default", "")
 	manifests, err := install.FillInTemplates(opts.TemplateParameters)
 	if err != nil {
 		return err

--- a/cmd/fluxctl/list_workloads_cmd.go
+++ b/cmd/fluxctl/list_workloads_cmd.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fluxcd/flux/pkg/api/v6"
+	v6 "github.com/fluxcd/flux/pkg/api/v6"
 	"github.com/fluxcd/flux/pkg/policy"
 )
 
@@ -30,7 +30,7 @@ func (opts *workloadListOpts) Command() *cobra.Command {
 		Example: makeExample("fluxctl list-workloads"),
 		RunE:    opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Confine query to namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Confine query to namespace")
 	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "a", false, "Query across all namespaces")
 	return cmd
 }
@@ -40,13 +40,16 @@ func (opts *workloadListOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
+	var ns string
 	if opts.allNamespaces {
-		opts.namespace = ""
+		ns = ""
+	} else {
+		ns = getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
 	}
 
 	ctx := context.Background()
 
-	workloads, err := opts.API.ListServices(ctx, opts.namespace)
+	workloads, err := opts.API.ListServices(ctx, ns)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadLockOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Controller namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Controller namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Workload to lock")
 
 	// Deprecated
@@ -50,10 +50,11 @@ func (opts *workloadLockOpts) RunE(cmd *cobra.Command, args []string) error {
 	case opts.controller != "":
 		opts.workload = opts.controller
 	}
+	ns := getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
 	policyOpts := &workloadPolicyOpts{
 		rootOpts:   opts.rootOpts,
 		outputOpts: opts.outputOpts,
-		namespace:  opts.namespace,
+		namespace:  ns,
 		workload:   opts.workload,
 		cause:      opts.cause,
 		lock:       true,

--- a/cmd/fluxctl/main_test.go
+++ b/cmd/fluxctl/main_test.go
@@ -67,7 +67,7 @@ func (t *genericMockRoundTripper) calledURL(method string) (u *url.URL) {
 func testArgs(t *testing.T, args []string, shouldErr bool, errMsg string) *genericMockRoundTripper {
 	svc := newMockService()
 	releaseClient := newWorkloadRelease(mockServiceOpts(svc))
-	getKubeConfigContextNamespace = func(s string) string { return s }
+	getKubeConfigContextNamespace = func(s string, c string) string { return s }
 
 	// Run fluxctl release
 	cmd := releaseClient.Command()

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -60,7 +60,7 @@ containers which aren't explicitly named.
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Workload namespace")
+	flags.StringVarP(&opts.namespace, "namespace", "n", "", "Workload namespace")
 	flags.StringVarP(&opts.workload, "workload", "w", "", "Workload to modify")
 	flags.StringVar(&opts.tagAll, "tag-all", "", "Tag filter pattern to apply to all containers")
 	flags.StringSliceVar(&opts.tags, "tag", nil, "Tag filter container/pattern pairs")
@@ -98,7 +98,8 @@ func (opts *workloadPolicyOpts) RunE(cmd *cobra.Command, args []string) error {
 		return newUsageError("lock and unlock both specified")
 	}
 
-	resourceID, err := resource.ParseIDOptionalNamespace(opts.namespace, opts.workload)
+	ns := getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
+	resourceID, err := resource.ParseIDOptionalNamespace(ns, opts.workload)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -19,6 +19,7 @@ import (
 )
 
 type rootOpts struct {
+	Context   string
 	URL       string
 	Token     string
 	Namespace string
@@ -70,6 +71,8 @@ func (opts *rootOpts) Command() *cobra.Command {
 		PersistentPreRunE: opts.PersistentPreRunE,
 	}
 
+	cmd.PersistentFlags().StringVar(&opts.Context, "context", "",
+		fmt.Sprint("The kubeconfig context to use, will use your current selected if not specified"))
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "k8s-fwd-ns", "default",
 		fmt.Sprintf("Namespace in which fluxd is running, for creating a port forward to access the API. No port forward will be created if a URL or token is given. You can also set the environment variable %s", envVariableNamespace))
 	cmd.PersistentFlags().StringToStringVar(&opts.Labels, "k8s-fwd-labels", map[string]string{"app": "flux"},
@@ -119,7 +122,7 @@ func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 	}
 
 	if opts.URL == "" {
-		portforwarder, err := tryPortforwards(opts.Namespace, metav1.LabelSelector{
+		portforwarder, err := tryPortforwards(opts.Context, opts.Namespace, metav1.LabelSelector{
 			MatchLabels: opts.Labels,
 		}, metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/cmd/fluxctl/unlock_cmd.go
+++ b/cmd/fluxctl/unlock_cmd.go
@@ -32,7 +32,7 @@ func (opts *workloadUnlockOpts) Command() *cobra.Command {
 	}
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", getKubeConfigContextNamespace("default"), "Controller namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Controller namespace")
 	cmd.Flags().StringVarP(&opts.workload, "workload", "w", "", "Controller to unlock")
 
 	// Deprecated
@@ -50,10 +50,11 @@ func (opts *workloadUnlockOpts) RunE(cmd *cobra.Command, args []string) error {
 	case opts.controller != "":
 		opts.workload = opts.controller
 	}
+	ns := getKubeConfigContextNamespaceOrDefault(opts.namespace, "default", opts.Context)
 	policyOpts := &workloadPolicyOpts{
 		rootOpts:   opts.rootOpts,
 		outputOpts: opts.outputOpts,
-		namespace:  opts.namespace,
+		namespace:  ns,
 		workload:   opts.workload,
 		cause:      opts.cause,
 		unlock:     true,

--- a/docs/references/fluxctl.md
+++ b/docs/references/fluxctl.md
@@ -224,6 +224,7 @@ Available Commands:
   version        Output the version of fluxctl
 
 Flags:
+      --context string                  The kubeconfig context to use
   -h, --help                            help for fluxctl
       --k8s-fwd-labels stringToString   Labels used to select the fluxd pod a port forward should be created for. You can also set the environment variable FLUX_FORWARD_LABELS (default [app=flux])
       --k8s-fwd-ns string               Namespace in which fluxd is running, for creating a port forward to access the API. No port forward will be created if a URL or token is given. You can also set the environment variable FLUX_FORWARD_NAMESPACE (default "default")


### PR DESCRIPTION
I'm building some shell scripts for our developers that includes fluxctl and since we have multiple contexts in our kubectl config this option is a must for some of our usage cases where id like to run fluxctl against different clusters
