### PR TITLE
Separate Git Poll Interval from Sync Interval

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -210,7 +210,8 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
 | `service.port`                                    | `3030`                                               | Service port to be used
 | `sync.state`                                      | `git`                                                | Where to keep sync state; either a tag in the upstream repo (`git`), or as an annotation on the SSH secret (`secret`)
-| `sync.timeout`                                    | `None`                                               |  Duration after which sync operations time out (defaults to `1m`)
+| `sync.timeout`                                    | `None`                                               | Duration after which sync operations time out (defaults to `1m`)
+| `sync.interval`                                   | `<git.pollInterval>`                                 | Controls how often Flux will apply what’s in git, to the cluster, absent new commits (defaults to `git.pollInterval`)
 | `git.url`                                         | `None`                                               | URL of git repo with Kubernetes manifests
 | `git.readonly`                                    | `false`                                              | If `true`, the git repo will be considered read-only, and Flux will not attempt to write to it
 | `git.branch`                                      | `master`                                             | Branch of git repo to use for Kubernetes manifests
@@ -257,10 +258,10 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `memcached.pullSecret`                            | `None`                                               | Image pull secret
 | `memcached.repository`                            | `memcached`                                          | Image repository
 | `memcached.resources`                             | `None`                                               | CPU/memory resource requests/limits for memcached
-| `memcached.securityContext`                       | [See values.yaml](/chart/flux/values.yaml#L192-L195) | Container security context for memcached
+| `memcached.securityContext`                       | [See values.yaml](/chart/flux/values.yaml#L176-L179) | Container security context for memcached
 | `memcached.nodeSelector`                          | `{}`                                                 | Node Selector properties for the memcached deployment
 | `memcached.tolerations`                           | `[]`                                                 | Tolerations properties for the memcached deployment
-| `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
+| `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L200-L212) | Override for kubectl default config in the Flux pod(s).
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
 | `prometheus.serviceMonitor.create`                | `false`                                              | Set to true if using the Prometheus Operator
 | `prometheus.serviceMonitor.interval`              | ``                                                   | Interval at which metrics should be scraped

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
           - --git-set-author={{ .Values.git.setAuthor }}
           - --git-poll-interval={{ .Values.git.pollInterval }}
           - --git-timeout={{ .Values.git.timeout }}
-          - --sync-interval={{ .Values.git.pollInterval }}
+          - --sync-interval={{ .Values.sync.interval | default .Values.git.pollInterval }}
           - --git-ci-skip={{ .Values.git.ciSkip }}
           {{- if .Values.git.label }}
           - --git-label={{ .Values.git.label }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -82,6 +82,10 @@ sync:
   state: git
   # Duration after which sync operations time out (defaults to 1m)
   timeout:
+  # Controls how often Flux will apply what’s in git, to the cluster, absent new commits.
+  # Reducing this interval below a minute or so may hinder Flux, since syncs can take tens of seconds,
+  # leaving not much time to do other operations.
+  #  interval: "5m"
 
 git:
   # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/fluxcd/flux-get-started


### PR DESCRIPTION
Allows for specifying different values for the git poll interval and sync interval. Previously, it used the `git.pollInterval` value for both. This behavior was fine if using a longer poll interval, but caused problems if setting the poll interval to a much shorter value (i.e., less than one minute).

By separating these values, the chart user can now use a short git poll interval (to quickly catch changes committed to git) while keeping the sync interval set to a longer interval, allowing Flux to operate normally without being overwhelmed by frequent syncs.