### PR TITLE
Sanitize Git remote URLs on the server side

### DIFF
--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -46,10 +46,10 @@ func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
 	case git.RepoReady:
 		break
 	default:
-		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.SafeURL(), string(gitConfig.Status))
+		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.URL, string(gitConfig.Status))
 	}
 
-	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.SafeURL())
+	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.URL)
 
 	updateSpec := update.Spec{
 		Type: update.Sync,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -622,6 +622,8 @@ func (d *Daemon) GitRepoConfig(ctx context.Context, regenerate bool) (v6.GitConf
 	}
 
 	origin := d.Repo.Origin()
+	// Sanitize the URL before sharing it
+	origin.URL = origin.SafeURL()
 	status, _ := d.Repo.Status()
 	path := ""
 	if len(d.GitConfig.Paths) > 0 {


### PR DESCRIPTION
It's safer than doing it on the client side (e.g. Flux users can be restricted to only port-forwarding to the Flux pod, not allowing them to see the git remote password).

Followup from #2549 . Fixes #2720 