### PR TITLE
e2e: check for GNU parallel and schedule defers before creation

### DIFF
--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -45,13 +45,13 @@ if ! kubectl version > /dev/null 2>&1; then
 
   echo '>>> Creating Kind Kubernetes cluster(s)'
   KIND_CONFIG_PREFIX="${HOME}/.kube/kind-config-${KIND_CLUSTER_PREFIX}"
-  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
   for I in $(seq 1 "${E2E_KIND_CLUSTER_NUM}"); do
     defer kind --name "${KIND_CLUSTER_PREFIX}-${I}" delete cluster > /dev/null 2>&1 || true
     defer rm -rf "${KIND_CONFIG_PREFIX}-${I}"
     # Wire tests with the right cluster based on their BATS_JOB_SLOT env variable
     eval export "KUBECONFIG_SLOT_${I}=${KIND_CONFIG_PREFIX}-${I}"
   done
+  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
 
   echo '>>> Loading images into the Kind cluster(s)'
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- kind --name "${KIND_CLUSTER_PREFIX}-{}" load docker-image 'docker.io/fluxcd/flux:latest'

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -37,6 +37,12 @@ E2E_KIND_CLUSTER_NUM=${E2E_KIND_CLUSTER_NUM:-1}
 if ! kubectl version > /dev/null 2>&1; then
   install_kind
 
+  # We require GNU Parallel, but some systems come with Tollef's parallel (moreutils)
+  if ! parallel -h | grep -q "GNU Parallel"; then
+    echo "GNU Parallel is not available on your system"
+    exit 1
+  fi
+
   echo '>>> Creating Kind Kubernetes cluster(s)'
   KIND_CONFIG_PREFIX="${HOME}/.kube/kind-config-${KIND_CLUSTER_PREFIX}"
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m


### PR DESCRIPTION
Backport of two changes made to the Helm operator end-to-end framework relevant to Flux.

- check if GNU Parallel is available on the system
- schedule cleanup defers before creation of Kind clusters
