### PR TITLE
Add connect option to connect to your own upstream service

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -198,6 +198,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `dnsPolicy`                                       | ``                                                   | Pod DNS policy
 | `dnsConfig`                                       | ``                                                   | Pod DNS config
 | `token`                                           | `None`                                               | Weave Cloud service token
+| `connect`                                         | `None`                                               | Address of upstream service to connect to
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
 | `env.secretName`                                  | ``                                                   | Name of the secret that contains environment variables which should be defined in the Flux container (using `envFrom`)
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -252,6 +252,9 @@ spec:
           {{- if .Values.token }}
           - --connect=wss://cloud.weave.works/api/flux
           - --token={{ .Values.token }}
+          {{- if .Values.connect }}
+          - --connect={{ .Values.connect }}
+          {{- end }}
           {{- end }}
           {{- if and .Values.syncGarbageCollection.enabled (not .Values.syncGarbageCollection.dry) }}
           - --sync-garbage-collection={{ .Values.syncGarbageCollection.enabled }}
@@ -277,7 +280,7 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
 {{- end }}
-      nodeSelector: 
+      nodeSelector:
         beta.kubernetes.io/os: linux
       {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -3,6 +3,8 @@
 # Weave Cloud service token
 token: ""
 
+connect: ""
+
 replicaCount: 1
 
 logFormat: fmt
@@ -35,7 +37,7 @@ serviceAccount:
   # Annotations for the Service Account
   annotations: {}
 
-# If create is `false` and no name is given, Flux will be restricted to 
+# If create is `false` and no name is given, Flux will be restricted to
 # namespaces listed in allowedNamespaces and the namespace where it is
 # deployed, and the kubeconfig default context will be set to that namespace.
 clusterRole:


### PR DESCRIPTION
This adds the ability to set your own upstream service (ie. `Fluxcloud` or other) when installing the helm chart