### PR TITLE
e2e: Update Kind to v0.7.0

### DIFF
--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -10,7 +10,8 @@ FLUX_ROOT_DIR="$(git rev-parse --show-toplevel)"
 E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
 CACHE_DIR="${FLUX_ROOT_DIR}/cache/$CURRENT_OS_ARCH"
 
-KIND_VERSION="v0.6.1"
+KIND_VERSION=v0.7.0
+KUBE_VERSION=v1.14.10
 KIND_CACHE_PATH="${CACHE_DIR}/kind-$KIND_VERSION"
 KIND_CLUSTER_PREFIX=flux-e2e
 BATS_EXTRA_ARGS=""
@@ -51,7 +52,7 @@ if ! kubectl version > /dev/null 2>&1; then
     # Wire tests with the right cluster based on their BATS_JOB_SLOT env variable
     eval export "KUBECONFIG_SLOT_${I}=${KIND_CONFIG_PREFIX}-${I}"
   done
-  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
+  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m --image kindest/node:${KUBE_VERSION}
 
   echo '>>> Loading images into the Kind cluster(s)'
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- kind --name "${KIND_CLUSTER_PREFIX}-{}" load docker-image 'docker.io/fluxcd/flux:latest'


### PR DESCRIPTION
- update Kind to `v0.7.0`
- set Kubernetes version to `1.14.10` for e2e tests

