### PR TITLE
Helm chart sops support

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -231,6 +231,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.config.data`                                 | `None`                                               | Global Git configuration per [git-config](https://git-scm.com/docs/git-config)
 | `gpgKeys.secretName`                              | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
 | `gpgKeys.configMapName`                           | `None`                                               | Kubernetes config map with public GPG keys the Flux daemon should import
+| `sops.enabled`                                    | `false`                                              | If `true` SOPS support will be enabled
 | `ssh.known_hosts`                                 | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
 | `registry.automationInterval`                     | `5m`                                                 | Period at which to check for updated images
 | `registry.rps`                                    | `200`                                                | Maximum registry requests per second per host

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -215,6 +215,9 @@ spec:
           {{- if .Values.git.label }}
           - --git-label={{ .Values.git.label }}
           {{- end }}
+          {{- if .Values.sops.enabled }}
+          - --sops={{ .Values.sops.enabled }}
+          {{- end }}
           {{- if .Values.manifestGeneration }}
           - --manifest-generation=true
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -132,6 +132,10 @@ git:
     #   [credential "https://github.com"]
     #           username = foo
 
+# If `true` SOPS support will be enabled
+sops:
+  enabled: false
+
 registry:
   # Period at which to check for updated images
   automationInterval: "5m"


### PR DESCRIPTION
Helm chart does not provide option to enable sops within values file. This would provide the expected user experience.

Fixes #2761
