### PR TITLE
Fixed Syntax error in image-tag script

### DIFF
--- a/docker/image-tag
+++ b/docker/image-tag
@@ -27,7 +27,7 @@ case ${#HEAD_TAGS[@]} in
        if [[ "${TAG2}" == v* && ${TAG2%$TAG1} == "v" ]]; then
            echo ${TAG1}; exit 0
        fi
-       ;&
+       ;;
 
     *) echo "error: more than one tag pointing to HEAD" >&2; exit 1; ;;
 esac


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
Hi!

Just a small change that I stumbled upon when attempting to build flux from source to work one some features and I kept getting the following error when running make. Running macOS Catalina `10.15`

```
/docker/image-tag: line 30: syntax error near unexpected token `;'
mkdir -p ./build/docker/flux
cp docker/Dockerfile.flux build/fluxd build/kubectl build/sops build/kustomize docker/ssh_config docker/kubeconfig docker/known_hosts.sh ./build/docker/flux/
sudo docker build -t docker.io/fluxcd/flux -t docker.io/fluxcd/flux: \
		--build-arg VCS_REF="a8edbc06f1a8ff08189e1da12e51ac7e86a01533" \
		--build-arg BUILD_DATE="2020-01-18T21:36:45Z" \
		-f build/docker/flux/Dockerfile.flux ./build/docker/flux
invalid argument "docker.io/fluxcd/flux:" for "-t, --tag" flag: invalid reference format
```

I took a the file and replaced the `;&' line on 30 with the follow `;;` and the build works perfect after the fix is applied.

```
make
mkdir -p ./build/docker/flux
cp docker/Dockerfile.flux build/fluxd build/kubectl build/sops build/kustomize docker/ssh_config docker/kubeconfig docker/known_hosts.sh ./build/docker/flux/
sudo docker build -t docker.io/fluxcd/flux -t docker.io/fluxcd/flux:image-tag-fix-a8edbc06-wip \
		--build-arg VCS_REF="a8edbc06f1a8ff08189e1da12e51ac7e86a01533" \
		--build-arg BUILD_DATE="2020-01-18T21:37:11Z" \
		-f build/docker/flux/Dockerfile.flux ./build/docker/flux
```