### PR TITLE
Add detailed error message in fluxctl sync

### DIFF
--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -46,7 +46,10 @@ func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
 	case git.RepoReady:
 		break
 	default:
-		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.URL, string(gitConfig.Status))
+		if gitConfig.Error != "" {
+			return fmt.Errorf("git repository %s is not ready to sync\n\nFull error message: %v", gitConfig.Remote.URL, gitConfig.Error)
+		}
+		return fmt.Errorf("git repository %s is not ready to sync", gitConfig.Remote.URL)
 	}
 
 	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.URL)

--- a/pkg/api/v6/api.go
+++ b/pkg/api/v6/api.go
@@ -58,6 +58,7 @@ type GitConfig struct {
 	Remote       GitRemoteConfig   `json:"remote"`
 	PublicSSHKey ssh.PublicKey     `json:"publicSSHKey"`
 	Status       git.GitRepoStatus `json:"status"`
+	Error        string            `json:"errors"`
 }
 
 type Deprecated interface {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -624,7 +624,12 @@ func (d *Daemon) GitRepoConfig(ctx context.Context, regenerate bool) (v6.GitConf
 	origin := d.Repo.Origin()
 	// Sanitize the URL before sharing it
 	origin.URL = origin.SafeURL()
-	status, _ := d.Repo.Status()
+	status, err := d.Repo.Status()
+	gitConfigError := ""
+	if err != nil {
+		gitConfigError = err.Error()
+	}
+
 	path := ""
 	if len(d.GitConfig.Paths) > 0 {
 		path = strings.Join(d.GitConfig.Paths, ",")
@@ -637,6 +642,7 @@ func (d *Daemon) GitRepoConfig(ctx context.Context, regenerate bool) (v6.GitConf
 		},
 		PublicSSHKey: publicSSHKey,
 		Status:       status,
+		Error:        gitConfigError,
 	}, nil
 }
 


### PR DESCRIPTION
* Extends v6.GitConfig to include `Error` field.

* In case of `fluxctl sync` error, prints the `Error` field
  in the output.

Closes #2657 

Signed-off-by: Dinos Kousidis <dinkousidis@gmail.com>


<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
