### PR TITLE
Update install docs to Helm v3

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -39,13 +39,18 @@ helm repo add fluxcd https://charts.fluxcd.io
 
 #### Install the chart with the release name `flux`
 
+1. Create the flux namespace:
+
+   ```sh
+   kubectl create namespace flux
+   ```
+
 1. Replace `fluxcd/flux-get-started` with your own git repository and run helm install:
 
    ```sh
-   helm install --name flux \
+   helm upgrade -i flux fluxcd/flux \
    --set git.url=git@github.com:fluxcd/flux-get-started \
-   --namespace flux \
-   fluxcd/flux
+   --namespace flux
    ```
 
 1. Setup Git deploy
@@ -92,11 +97,10 @@ to securely provide the HTTPS credentials which then can be used in the
 1. Install Flux:
 
    ```sh
-   helm install --name flux \
+   helm upgrade -i flux fluxcd/flux \
    --set git.url='https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/fluxcd/flux-get-started.git' \
    --set env.secretName=flux-git-auth \
-   --namespace flux \
-   fluxcd/flux
+   --namespace flux
    ```
 
 #### Flux with a private git host
@@ -130,12 +134,10 @@ called `flux-ssh-config` which in turn will be mounted into a volume named
      domain ecdsa-sha2-line2
      domain ssh-ed25519 line3'
 
-     helm install \
-     --name flux \
+     helm upgrade -i flux fluxcd/flux \
      --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
      --set-string ssh.known_hosts="${KNOWN_HOSTS}" \
-     --namespace flux \
-     fluxcd/flux
+     --namespace flux
      ```
 
    - Using a file for setting `known_hosts`
@@ -146,22 +148,19 @@ called `flux-ssh-config` which in turn will be mounted into a volume named
      YOUR_GIT_HOST=your_git_host.example.com
      YOUR_GIT_USER=your_git_user
 
-     helm install \
-     --name flux \
+     helm upgrade -i flux fluxcd/flux \
      --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
      --set-file ssh.known_hosts=/tmp/flux_known_hosts \
-     --namespace flux \
-     fluxcd/flux
+     --namespace flux
      ```
 
 #### Connect Flux to a Weave Cloud instance
 
 ```sh
-helm install --name flux \
+helm upgrade -i flux fluxcd/flux \
 --set git.url=git@github.com:fluxcd/flux-get-started \
 --set token=YOUR_WEAVE_CLOUD_SERVICE_TOKEN \
---namespace flux \
-fluxcd/flux
+--namespace flux
 ```
 
 ### Uninstalling the Chart
@@ -169,7 +168,7 @@ fluxcd/flux
 To uninstall/delete the `flux` deployment:
 
 ```sh
-helm delete --purge flux
+helm delete flux
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -276,7 +275,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```sh
-helm upgrade --install --wait flux \
+helm upgrade -i flux fluxcd/flux \
 --set git.url=git@github.com:stefanprodan/k8s-podinfo \
 --set git.path="deploy/auto-scaling\,deploy/local-storage" \
 --namespace flux \
@@ -288,7 +287,6 @@ fluxcd/flux
 Update Flux version with:
 
 ```sh
-helm upgrade --reuse-values flux \
---set image.tag=1.8.1 \
-fluxcd/flux
+helm upgrade --reuse-values flux fluxcd/flux \
+--set image.tag=1.17.1
 ```

--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -14,7 +14,7 @@ You will need to have Kubernetes set up. To get up and running fast,
 you might want to use `minikube` or `kubeadm`. Any other Kubernetes
 setup will work as well though.
 
-Download Helm:
+Download Helm v3:
 
 - On MacOS:
 
@@ -26,7 +26,7 @@ Download Helm:
   - Download the [latest release](https://github.com/kubernetes/helm/releases/latest),
     unpack the tarball and put the binary in your `$PATH`.
 
-Now create a service account and a cluster role binding for Tiller:
+If you are using Helm v2 you have to create a service account and a cluster role binding for Tiller:
 
 ```sh
 kubectl -n kube-system create sa tiller
@@ -36,7 +36,7 @@ kubectl create clusterrolebinding tiller-cluster-rule \
     --serviceaccount=kube-system:tiller
 ```
 
-Deploy Tiller in `kube-system` namespace:
+Deploy Tiller in `kube-system` namespace (Helm v2 only):
 
 ```sh
 helm init --skip-refresh --upgrade --service-account tiller --history-max 10
@@ -66,6 +66,13 @@ In this next step you install Flux using `helm`. Simply
  1. Fork [`fluxcd/flux-get-started`](https://github.com/fluxcd/flux-get-started)
     on GitHub and replace the `fluxcd` with your GitHub username in
     [here](https://github.com/fluxcd/flux-get-started/blob/master/releases/ghost.yaml#L13)
+ 
+ 1. Create the flux namespace:
+ 
+    ```sh
+    kubectl create namespace flux
+    ```
+ 
  1. Install Flux and the Helm operator by specifying your fork URL:
 
       *Just make sure you replace `YOURUSER` with your GitHub username
@@ -74,15 +81,13 @@ In this next step you install Flux using `helm`. Simply
     - Using a public git server from `bitbucket.com`, `github.com`, `gitlab.com`, `dev.azure.com`, or `vs-ssh.visualstudio.com`:
 
       ```sh
-      helm upgrade -i flux \
+      helm upgrade -i flux fluxcd/flux \
       --set git.url=git@github.com:YOURUSER/flux-get-started \
-      --namespace flux \
-      fluxcd/flux
-      
-      helm upgrade -i helm-operator \
+      --namespace flux 
+
+      helm upgrade -i helm-operator fluxcd/helm-operator \
       --set git.ssh.secretName=flux-git-deploy \
-      --namespace flux \
-      fluxcd/helm-operator
+      --namespace flux
       ```
 
     - Using a private git server:
@@ -157,7 +162,7 @@ change the `tag:` line to the following:
   values:
     image:
       repository: bitnami/mongodb
-      tag: 4.0.6
+      tag: 4.0.14
 ```
 
 Commit the change to your `master` branch. It will now get


### PR DESCRIPTION
Make the Helm install instructions compatible with Helm v3 and v2.
Fix: #2769 
