### PR TITLE
Add podLabels to values.yaml & update deployment.yaml

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -228,6 +228,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.config.enabled`                              | `false`                                              | Mount `$HOME/.gitconfig` via Secret into the Flux and HelmOperator Pods, allowing for custom global Git configuration
 | `git.config.secretName`                           | `Computed`                                           | Kubernetes secret with the global Git configuration
 | `git.config.data`                                 | `None`                                               | Global Git configuration per [git-config](https://git-scm.com/docs/git-config)
+| `podLabels`                                       | `{}`                                                 | Additional labels for the Flux pod
 | `gpgKeys.secretName`                              | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
 | `gpgKeys.configMapName`                           | `None`                                               | Kubernetes config map with public GPG keys the Flux daemon should import
 | `sops.enabled`                                    | `false`                                              | If `true` SOPS support will be enabled

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -25,6 +25,11 @@ spec:
       labels:
         app: {{ template "flux.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
       {{- if .Values.image.pullSecret }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -53,6 +53,8 @@ nodeSelector: {}
 
 annotations: {}
 
+podLabels: {}
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
Helm chart does not provide option to add custom labels within values file. This would allow more extendable use cases for using custom selectors.

Example use case: https://github.com/Azure/aad-pod-identity#5-install-the-azure-identity-binding

Fixes #2774 