### PR TITLE
Make clone cleanups more robust

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -652,7 +652,11 @@ func (d *Daemon) WithWorkingClone(ctx context.Context, fn func(*git.Checkout) er
 	if err != nil {
 		return err
 	}
-	defer co.Clean()
+	defer func() {
+		if err := co.Clean(); err != nil {
+			d.Logger.Log("error", fmt.Sprintf("cannot clean working clone: %s", err))
+		}
+	}()
 	if d.GitSecretEnabled {
 		if err := co.SecretUnseal(ctx); err != nil {
 			return err
@@ -673,7 +677,11 @@ func (d *Daemon) WithReadonlyClone(ctx context.Context, fn func(*git.Export) err
 	if err != nil {
 		return err
 	}
-	defer co.Clean()
+	defer func() {
+		if err := co.Clean(); err != nil {
+			d.Logger.Log("error", fmt.Sprintf("cannot read-only clone: %s", err))
+		}
+	}()
 	if d.GitSecretEnabled {
 		if err := co.SecretUnseal(ctx); err != nil {
 			return err

--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"github.com/fluxcd/flux/pkg/metrics"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -48,7 +49,11 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 		return err
 	}
 	cancel()
-	defer working.Clean()
+	defer func() {
+		if err := working.Clean(); err != nil {
+			d.Logger.Log("error", fmt.Sprintf("cannot clean sync clone: %s", err))
+		}
+	}()
 
 	// Unseal any secrets if enabled
 	if d.GitSecretEnabled {

--- a/pkg/git/export.go
+++ b/pkg/git/export.go
@@ -14,10 +14,11 @@ func (e *Export) Dir() string {
 	return e.dir
 }
 
-func (e *Export) Clean() {
+func (e *Export) Clean() error {
 	if e.dir != "" {
-		os.RemoveAll(e.dir)
+		return os.RemoveAll(e.dir)
 	}
+	return nil
 }
 
 // Export creates a minimal clone of the repo, at the ref given.

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -488,7 +488,7 @@ func (r *Repo) workingClone(ctx context.Context, ref string) (string, error) {
 	}
 	path, err := clone(ctx, working, r.dir, ref)
 	if err != nil {
-		os.RemoveAll(path)
+		os.RemoveAll(working)
 	}
 	return path, err
 }

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -486,5 +486,9 @@ func (r *Repo) workingClone(ctx context.Context, ref string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return clone(ctx, working, r.dir, ref)
+	path, err := clone(ctx, working, r.dir, ref)
+	if err != nil {
+		os.RemoveAll(path)
+	}
+	return path, err
 }

--- a/pkg/sync/git.go
+++ b/pkg/sync/git.go
@@ -66,6 +66,7 @@ func (p GitTagSyncProvider) UpdateMarker(ctx context.Context, revision string) e
 	if err != nil {
 		return err
 	}
+	defer checkout.Clean()
 	return checkout.MoveTagAndPush(ctx, git.TagAction{
 		Tag:        p.syncTag,
 		Revision:   revision,


### PR DESCRIPTION
* Fixes a systematic clone leak (introduced in #1807 , released in 1.14 ) in every bump of the sync tag. This probably justifies a new patch release and it probably fixes #2713 . I still don't understand how this has escaped our radar until #2713  
* Removes the temporary cloning directory if `git clone` fails for whatever reason
* It stops hiding underlying errors in`Export.Clean()` and prints them wherever a logger is available (not perfect, but better).