### PR TITLE
Fix `make generate-deploy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ generate-deploy: $(GOBIN)/fluxctl
 		--namespace flux
 
 $(GENERATED_TEMPLATES_FILE): pkg/install/templates/*.tmpl pkg/install/generate.go
-	go generate ./pkg/install
+	cd ./pkg/install &&  go generate .
 
 check-generated: generate-deploy
 	git diff --exit-code -- deploy/

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build tools
 
 package main
 

--- a/pkg/install/go.mod
+++ b/pkg/install/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
+	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/tools v0.0.0-20200121210457-b3205ff6fffe // indirect
 )

--- a/pkg/install/go.sum
+++ b/pkg/install/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/spf13/afero v1.1.1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cobra v0.0.0-20180820174524-ff0d02e85550 h1:LB9SHuuXO8gnsHtexOQSpsJrrAHYA35lvHUaE74kznU=


### PR DESCRIPTION
It was failing with

```
$ make generate-deploy
go generate ./pkg/install
go: directory pkg/install is outside main module
make: *** [pkg/install/generated_templates.gogen.go] Error 1
```

Also, make sure that the dependencies of `pkg/install/generate.go` are included in `go.mod` (I didn't know that the `tools` build tag was treated specially).

Followup from #2779 