### PR TITLE
Fix syncing with --k8s-default-namespace

### DIFF
--- a/pkg/cluster/kubernetes/sync.go
+++ b/pkg/cluster/kubernetes/sync.go
@@ -377,6 +377,15 @@ func applyMetadata(res resource.Resource, syncSetName, checksum string) ([]byte,
 		mixin["labels"] = mixinLabels
 	}
 
+	// After loading the manifest the namespace of the resource can change
+	// (e.g. a default namespace is applied)
+	// The `ResourceID` should give us the up-to-date value
+	// (see `KubeManifest.SetNamespace`)
+	namespace, _, _ := res.ResourceID().Components()
+	if namespace != kresource.ClusterScope {
+		mixin["namespace"] = namespace
+	}
+
 	if checksum != "" {
 		mixinAnnotations := map[string]string{}
 		mixinAnnotations[checksumAnnotation] = checksum


### PR DESCRIPTION
Fixes https://github.com/fluxcd/flux/issues/2797

The problem was that the namespace was set on the `KubeManifest` next to the raw `Resource` but then when the `KubeManifest` is synced as a `Resource`, the raw bytes are taken.
Since we're reserializing in `applyMetadata` anyway, I just update the namespace there.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
