### PR TITLE
Remove obsolete `integration-test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,9 +162,6 @@ $(GOBIN)/fluxctl: $(FLUXCTL_DEPS) $(GENERATED_TEMPLATES_FILE)
 $(GOBIN)/fluxd: $(FLUXD_DEPS)
 	go install ./cmd/fluxd
 
-integration-test: all
-	test/bin/test-flux
-
 generate-deploy: $(GOBIN)/fluxctl
 	$(GOBIN)/fluxctl install -o ./deploy \
 		--git-url git@github.com:fluxcd/flux-get-started \


### PR DESCRIPTION
[As reported by a user on Slack](https://weave-community.slack.com/archives/C4U5ATZ9S/p1580801044318500), this should lead to less confusion.