### PR TITLE
docs/clarify flux's dependency on the ec2 metadata api

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -155,10 +155,19 @@ To work around exceptional cases, you can mount a docker config into
 the Flux container. See the argument `--docker-config` in [the daemon
 arguments reference](references/daemon.md).
 
-For ECR, if you are using Kiam, you need to whitelist the following API routes:
-```
---whitelist-route-regexp=(/latest/meta-data/placement/availability-zone|/latest/dynamic/instance-identity/document)
-```
+For ECR, Flux requires access to the EC2 instance metadata API to
+obtain AWS credentials. Kube2iam, Kiam, and potentially other
+Kuberenetes IAM utilities may block pod level access to the EC2
+metadata APIs. If this is the case, Flux will be unable to poll ECR
+for automated workloads.
+
+ -  If you are using Kiam, you need to whitelist the following API routes:
+      ```
+      --whitelist-route-regexp=(/latest/meta-data/placement/availability-zone|/latest/dynamic/instance-identity/document)
+      ```
+ - If you are using kube2iam, ensure the values of --iptables and
+    --in-interface are [configured correctly for your virtual network
+    provider](https://github.com/jtblin/kube2iam#iptables).
 
 See also
 [Why are my images not showing up in the list of images?](#why-are-my-images-not-showing-up-in-the-list-of-images)


### PR DESCRIPTION
This pull request is a documentation enhancement to the dependency between flux and the ec2 instance metadata api when polling ecr. This enhancement calls out that kube2iam and kiam are designed to limit pod level access to the metadata api and provides information on how to configure both kube2iam and kiam. 