### PR TITLE
Adds support for registry-disable-scanning flag in Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -239,6 +239,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `registry.trace`                                  | `false`                                              | Output trace of image registry requests to log
 | `registry.insecureHosts`                          | `None`                                               | Use HTTP rather than HTTPS for the image registry domains
 | `registry.cacheExpiry`                            | `None`                                               | Duration to keep cached image info (deprecated)
+| `registry.disableScanning`                        | `false`                                              | Disable registry scanning completely
 | `registry.excludeImage`                           | `None`                                               | Do not scan images that match these glob expressions; if empty, 'k8s.gcr.io/*' images are excluded
 | `registry.useTimestampLabels`                     | `None`                                               | Allow usage of (RFC3339) timestamp labels from (canonical) image refs that match these glob expressions; if empty, 'index.docker.io/{weaveworks,fluxcd}/*' images are allowed
 | `registry.ecr.region`                             | `None`                                               | Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -239,6 +239,9 @@ spec:
           {{- if .Values.registry.cacheExpiry }}
           - --registry-cache-expiry={{ .Values.registry.cacheExpiry }}
           {{- end }}
+          {{- if .Values.registry.disableScanning }}
+          - --registry-disable-scanning
+          {{- end }}
           {{- if .Values.registry.excludeImage }}
           - --registry-exclude-image={{ .Values.registry.excludeImage }}
           {{- end }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.memcached.enabled true) (eq .Values.git.readonly false) }}
+{{- if and (eq .Values.memcached.enabled true) (eq .Values.git.readonly false) (eq .Values.registry.disableScanning false)  }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -151,6 +151,8 @@ registry:
   insecureHosts:
   # Duration to keep cached image info. Must be < 1 month. (Deprecated)
   cacheExpiry:
+  # Disable registry scanning completely
+  disableScanning: false
   # Do not scan images that match these glob expressions
   excludeImage:
   # Allow usage of (RFC3339) timestamp labels from (canonical) image refs that match these glob expressions


### PR DESCRIPTION
This PR adds support for the `--registry-disable-scanning` flag introduced in Flux `1.18.0` to the Helm chart.