### PR TITLE
Add note about targeting a specific Helm version for the Helm operator

### DIFF
--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -83,12 +83,14 @@ In this next step you install Flux using `helm`. Simply
       ```sh
       helm upgrade -i flux fluxcd/flux \
       --set git.url=git@github.com:YOURUSER/flux-get-started \
-      --namespace flux 
+      --namespace flux
 
       helm upgrade -i helm-operator fluxcd/helm-operator \
       --set git.ssh.secretName=flux-git-deploy \
       --namespace flux
       ```
+
+    > **Note:** By default the helm-operator chart will install with support for both Helm v2 (which requires Tiller) and v3.  You can target specific versions by setting the `helm.versions` value, e.g. `--set helm.versions=v3`.
 
     - Using a private git server:
 


### PR DESCRIPTION
Update "Get started with Flux using Helm" tutorial to include an example of installing the Helm operator for users using Helm v3.  The current example installs the Helm operator for Helm v2 causing the helm-operator pod to crash with the following error if you are using Helm v3:

> ts=2020-02-06T21:04:41.725026537Z caller=helm.go:59 component=helm version=v2 error="error creating Client (v2) client: services \"tiller-deploy\" not found"