### PR TITLE
Add support for bash/zsh completion

### DIFF
--- a/cmd/fluxctl/completion_cmd.go
+++ b/cmd/fluxctl/completion_cmd.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
+		"bash": runCompletionBash,
+		"zsh":  runCompletionZsh,
+	}
+)
+
+func newCompletionCommand() *cobra.Command {
+	shells := []string{}
+	for s := range completionShells {
+		shells = append(shells, s)
+	}
+
+	return &cobra.Command{
+		Use:                   "completion SHELL",
+		DisableFlagsInUseLine: true,
+		Short:                 "Output shell completion code for the specified shell (bash or zsh)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return newUsageError("please specify a shell")
+			}
+
+			if len(args) > 1 {
+				return newUsageError(fmt.Sprintf("please specify one of the following shells: %s", strings.Join(shells, " ")))
+			}
+
+			run, found := completionShells[args[0]]
+			if !found {
+				return newUsageError(fmt.Sprintf("unsupported shell type %q.", args[0]))
+			}
+
+			return run(cmd.OutOrStdout(), cmd.Parent())
+		},
+		ValidArgs: shells,
+	}
+}
+
+func runCompletionBash(out io.Writer, fluxctl *cobra.Command) error {
+	return fluxctl.GenBashCompletion(out)
+}
+
+func runCompletionZsh(out io.Writer, fluxctl *cobra.Command) error {
+	return fluxctl.GenZshCompletion(out)
+}

--- a/cmd/fluxctl/completion_cmd_test.go
+++ b/cmd/fluxctl/completion_cmd_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCompletionCommand_InputFailure(t *testing.T) {
+	for k, v := range [][]string{
+		{},
+		{"foo"},
+		{"bash", "zsh"},
+	} {
+		t.Run(fmt.Sprintf("%d", k), func(t *testing.T) {
+			cmd := newCompletionCommand()
+			cmd.SetArgs(v)
+			if err := cmd.Execute(); err == nil {
+				t.Fatalf("Expecting error: command is expecting either bash or zsh")
+			}
+		})
+	}
+}
+
+func TestCompletionCommand_Success(t *testing.T) {
+	for k, v := range [][]string{
+		{"bash"},
+		{"zsh"},
+	} {
+		t.Run(fmt.Sprintf("%d", k), func(t *testing.T) {
+			parentCmd := newRoot().Command()
+			cmd := newCompletionCommand()
+			parentCmd.AddCommand(cmd)
+			cmd.SetArgs(v)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Expecting nil, got error (%s)", err.Error())
+			}
+		})
+	}
+}

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -97,6 +97,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		newIdentity(opts).Command(),
 		newSync(opts).Command(),
 		newInstall().Command(),
+		newCompletionCommand(),
 	)
 
 	return cmd
@@ -105,7 +106,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 	// skip port forward for certain commands
 	switch cmd.Use {
-	case "version":
+	case "version", "completion SHELL":
 		fallthrough
 	case "install":
 		return nil


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->

- Add support for bash and zsh completion
- Currently using the builtin cobra generated scripts but can be extended to support nouns

Fixes #1593 
