### PR TITLE
Add JSON output option for fluxctl's list-images and list-workloads

### DIFF
--- a/cmd/fluxctl/error.go
+++ b/cmd/fluxctl/error.go
@@ -29,3 +29,4 @@ func checkExactlyOne(optsDescription string, supplied ...bool) error {
 }
 
 var errorWantedNoArgs = newUsageError("expected no (non-flag) arguments")
+var errorInvalidOutputFormat = newUsageError("invalid output format specified")

--- a/cmd/fluxctl/format.go
+++ b/cmd/fluxctl/format.go
@@ -2,10 +2,19 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/fluxcd/flux/pkg/registry"
+
+	v6 "github.com/fluxcd/flux/pkg/api/v6"
 
 	"github.com/spf13/cobra"
 )
@@ -13,6 +22,13 @@ import (
 type outputOpts struct {
 	verbosity int
 }
+
+const (
+	outputFormatJson = "json"
+	outputFormatTab  = "tab"
+)
+
+var validOutputFormats = []string{outputFormatJson, outputFormatTab}
 
 func AddOutputFlags(cmd *cobra.Command, opts *outputOpts) {
 	cmd.Flags().CountVarP(&opts.verbosity, "verbose", "v", "include skipped (and ignored, with -vv) workloads in output")
@@ -28,4 +44,145 @@ func makeExample(examples ...string) string {
 		fmt.Fprintf(&buf, "  "+ex+"\n")
 	}
 	return strings.TrimSuffix(buf.String(), "\n")
+}
+
+func outputFormatIsValid(format string) bool {
+	for _, f := range validOutputFormats {
+		if f == format {
+			return true
+		}
+	}
+	return false
+}
+
+// outputImagesJson sends the provided ImageStatus info to the io.Writer in JSON formatting, honoring limits in opts
+func outputImagesJson(images []v6.ImageStatus, out io.Writer, opts *imageListOpts) error {
+	if opts.limit < 0 {
+		return errors.New("opts.limit cannot be less than 0")
+	}
+	var sliceLimit int
+
+	// Truncate the Available container images to honor the lesser of
+	// opts.limit or the total number of Available
+	for i := 0; i < len(images); i++ {
+		containerImages := images[i]
+		for i := 0; i < len(containerImages.Containers); i++ {
+			if opts.limit != 0 {
+				available := containerImages.Containers[i].Available
+				if len(available) < opts.limit {
+					sliceLimit = len(available)
+				} else {
+					sliceLimit = opts.limit
+				}
+				containerImages.Containers[i].Available = containerImages.Containers[i].Available[:sliceLimit]
+			}
+		}
+	}
+
+	e := json.NewEncoder(out)
+	if err := e.Encode(images); err != nil {
+		return err
+	}
+	return nil
+}
+
+// outputImagesTab sends the provided ImageStatus info to os.Stdout in tab formatting, honoring limits in opts
+func outputImagesTab(images []v6.ImageStatus, opts *imageListOpts) {
+	out := newTabwriter()
+
+	if !opts.noHeaders {
+		fmt.Fprintln(out, "WORKLOAD\tCONTAINER\tIMAGE\tCREATED")
+	}
+
+	for _, image := range images {
+		if len(image.Containers) == 0 {
+			fmt.Fprintf(out, "%s\t\t\t\n", image.ID)
+			continue
+		}
+
+		imageName := image.ID.String()
+		for _, container := range image.Containers {
+			var lineCount int
+			containerName := container.Name
+			reg, repo, currentTag := container.Current.ID.Components()
+			if reg != "" {
+				reg += "/"
+			}
+			if len(container.Available) == 0 {
+				availableErr := container.AvailableError
+				if availableErr == "" {
+					availableErr = registry.ErrNoImageData.Error()
+				}
+				fmt.Fprintf(out, "%s\t%s\t%s%s\t%s\n", imageName, containerName, reg, repo, availableErr)
+			} else {
+				fmt.Fprintf(out, "%s\t%s\t%s%s\t\n", imageName, containerName, reg, repo)
+			}
+			foundRunning := false
+			for _, available := range container.Available {
+				running := "|  "
+				_, _, tag := available.ID.Components()
+				if currentTag == tag {
+					running = "'->"
+					foundRunning = true
+				} else if foundRunning {
+					running = "   "
+				}
+
+				lineCount++
+				var printEllipsis, printLine bool
+				if opts.limit <= 0 || lineCount <= opts.limit {
+					printEllipsis, printLine = false, true
+				} else if container.Current.ID == available.ID {
+					printEllipsis, printLine = lineCount > (opts.limit+1), true
+				}
+				if printEllipsis {
+					fmt.Fprintf(out, "\t\t%s (%d image(s) omitted)\t\n", ":", lineCount-opts.limit-1)
+				}
+				if printLine {
+					createdAt := ""
+					if !available.CreatedAt.IsZero() {
+						createdAt = available.CreatedAt.Format(time.RFC822)
+					}
+					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, createdAt)
+				}
+			}
+			if !foundRunning {
+				running := "'->"
+				if currentTag == "" {
+					currentTag = "(untagged)"
+				}
+				fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, currentTag, "?")
+
+			}
+			imageName = ""
+		}
+	}
+	out.Flush()
+}
+
+// outputWorkloadsJson sends the provided Workload data to the io.Writer as JSON
+func outputWorkloadsJson(workloads []v6.ControllerStatus, out io.Writer) error {
+	encoder := json.NewEncoder(out)
+	return encoder.Encode(workloads)
+}
+
+// outputWorkloadsTab sends the provided Workload data to STDOUT, formatted with tabs for CLI
+func outputWorkloadsTab(workloads []v6.ControllerStatus, opts *workloadListOpts) {
+	w := newTabwriter()
+	if !opts.noHeaders {
+		fmt.Fprintf(w, "WORKLOAD\tCONTAINER\tIMAGE\tRELEASE\tPOLICY\n")
+	}
+
+	for _, workload := range workloads {
+		if len(workload.Containers) > 0 {
+			c := workload.Containers[0]
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", workload.ID, c.Name, c.Current.ID, workload.Status, policies(workload))
+			for _, c := range workload.Containers[1:] {
+				fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
+			}
+		} else {
+			fmt.Fprintf(w, "%s\t\t\t%s\t%s\n", workload.ID, workload.Status, policies(workload))
+		}
+	}
+	w.Flush()
 }

--- a/cmd/fluxctl/list_images_cmd_test.go
+++ b/cmd/fluxctl/list_images_cmd_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fluxcd/flux/pkg/image"
+	"github.com/fluxcd/flux/pkg/update"
+
+	v6 "github.com/fluxcd/flux/pkg/api/v6"
+)
+
+func Test_outputImagesJson(t *testing.T) {
+	opts := &imageListOpts{limit: 10} // 10 is the default from the flag
+
+	t.Run("sends JSON to the io.Writer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		images := testImages(opts.limit)
+		err := outputImagesJson(images, buf, opts)
+		require.NoError(t, err)
+		unmarshallTarget := &[]v6.ImageStatus{}
+		err = json.Unmarshal(buf.Bytes(), unmarshallTarget)
+		require.NoError(t, err)
+	})
+
+	t.Run("respects provided limit on Available container images", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		images := testImages(100)
+		_ = outputImagesJson(images, buf, opts)
+
+		unmarshallTarget := &[]v6.ImageStatus{}
+		_ = json.Unmarshal(buf.Bytes(), unmarshallTarget)
+
+		imageSlice := *unmarshallTarget
+		availableListSize := len(imageSlice[0].Containers[0].Available)
+
+		assert.Equal(t, opts.limit, availableListSize)
+	})
+
+	t.Run("provides all when limit is 0", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		opts := &imageListOpts{limit: 0} // 0 means all
+		count := 100
+		images := testImages(count)
+		_ = outputImagesJson(images, buf, opts)
+
+		unmarshallTarget := &[]v6.ImageStatus{}
+		_ = json.Unmarshal(buf.Bytes(), unmarshallTarget)
+
+		imageSlice := *unmarshallTarget
+		availableListSize := len(imageSlice[0].Containers[0].Available)
+
+		assert.Equal(t, count, availableListSize)
+	})
+
+	t.Run("returns an error on a bad limit", func(t *testing.T) {
+		badLimitOpts := &imageListOpts{limit: -1}
+		buf := &bytes.Buffer{}
+		images := testImages(10)
+		err := outputImagesJson(images, buf, badLimitOpts)
+		assert.Error(t, err)
+	})
+}
+
+// testImages returns a single-member collection of ImageStatus objects with
+// an optional number of Available images on the only Container
+func testImages(availableCount int) []v6.ImageStatus {
+	containerWithAvailable := []v6.Container{{Name: "TestContainer"}}
+
+	images := []v6.ImageStatus{{Containers: containerWithAvailable}}
+	available := update.SortedImageInfos{}
+
+	for i := 0; i < availableCount; i++ {
+		digest := fmt.Sprintf("abc123%d", i)
+		imageID := fmt.Sprintf("deadbeef%d", i)
+		testImage := image.Info{
+			ID:          image.Ref{},
+			Digest:      digest,
+			ImageID:     imageID,
+			Labels:      image.Labels{},
+			CreatedAt:   time.Time{},
+			LastFetched: time.Time{},
+		}
+
+		available = append(available, testImage)
+	}
+
+	images[0].Containers[0].Available = available
+
+	return images
+}

--- a/cmd/fluxctl/list_workloads_cmd_test.go
+++ b/cmd/fluxctl/list_workloads_cmd_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fluxcd/flux/pkg/cluster"
+
+	"github.com/fluxcd/flux/pkg/resource"
+
+	v6 "github.com/fluxcd/flux/pkg/api/v6"
+)
+
+func Test_outputWorkloadsJson(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	t.Run("sends JSON to the io.Writer", func(t *testing.T) {
+		workloads := testWorkloads(5)
+		err := outputWorkloadsJson(workloads, buf)
+		require.NoError(t, err)
+		unmarshallTarget := &[]v6.ControllerStatus{}
+		err = json.Unmarshal(buf.Bytes(), unmarshallTarget)
+		require.NoError(t, err)
+	})
+}
+
+func testWorkloads(workloadCount int) []v6.ControllerStatus {
+	workloads := []v6.ControllerStatus{}
+	for i := 0; i < workloadCount; i++ {
+		name := fmt.Sprintf("mah-app-%d", i)
+		id := resource.MakeID("applications", "deployment", name)
+
+		cs := v6.ControllerStatus{
+			ID:         id,
+			Containers: nil,
+			ReadOnly:   "",
+			Status:     "ready",
+			Rollout:    cluster.RolloutStatus{},
+			SyncError:  "",
+			Antecedent: resource.ID{},
+			Labels:     nil,
+			Automated:  false,
+			Locked:     false,
+			Ignore:     false,
+			Policies:   nil,
+		}
+
+		workloads = append(workloads, cs)
+
+	}
+	return workloads
+}


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->

## What
A JSON output option for `fluxctl list-workloads` and `fluxctl list-images`

## Why
Building tooling (such as chatbot functionality) is much easier with a machine-readable output.

## Note
I added [Testify](https://github.com/stretchr/testify) to the test build b/c I think that the single-line assertions make test code really easy to read. If this is controversial, I can remove. It tends to be the single thing that I use outside of stdlib for tests.