### PR TITLE
cmd/fluxctl: Support passing additional arguments to fluxd via fluxctl install

### DIFF
--- a/cmd/fluxctl/install_cmd.go
+++ b/cmd/fluxctl/install_cmd.go
@@ -52,6 +52,7 @@ fluxctl install --git-url 'git@github.com:<your username>/flux-get-started' --gi
 		"do not scan container image registries to fill in the registry cache")
 	cmd.Flags().StringVarP(&opts.outputDir, "output-dir", "o", "", "a directory in which to write individual manifests, rather than printing to stdout")
 	cmd.Flags().BoolVar(&opts.AddSecurityContext, "add-security-context", true, "Ensure security context information is added to the pod specs. Defaults to 'true'")
+	cmd.Flags().StringSliceVar(&opts.AdditionalFluxArgs, "additional-flux-args", nil, "A comma separated list of additional arguments to pass to fluxd")
 
 	// Hide and deprecate "git-paths", which was wrongly introduced since its inconsistent with fluxd's git-path flag
 	cmd.Flags().MarkHidden("git-paths")


### PR DESCRIPTION
Adds the ability to pass arbitrary additional args to `fluxd` via `fluxctl install`. Useful for setting flags like `--sync-garbage-collection`.