### PR TITLE
Support setting `priorityClassName` for memcached

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -265,6 +265,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `memcached.securityContext`                       | [See values.yaml](/chart/flux/values.yaml#L176-L179) | Container security context for memcached
 | `memcached.nodeSelector`                          | `{}`                                                 | Node Selector properties for the memcached deployment
 | `memcached.tolerations`                           | `[]`                                                 | Tolerations properties for the memcached deployment
+| `memcached.priorityClassName`                     | `""`                                                 | The name of the priority class to assign to the memcached pod.
 | `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L200-L212) | Override for kubectl default config in the Flux pod(s).
 | `priorityClassName`                               | `""`                                                 | Set priority class for Flux
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -26,6 +26,9 @@ spec:
         app: {{ template "flux.name" . }}-memcached
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.memcached.priorityClassName }}
+      priorityClassName: {{ .Values.memcached.priorityClassName }}
+      {{- end }}
       {{- if .Values.memcached.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.memcached.pullSecret }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -210,6 +210,7 @@ memcached:
     # requests:
     #  cpu: 50m
     #  memory: 512Mi
+  priorityClassName: ""
 
 ssh:
   # Overrides for git over SSH. If you use your own git server, you


### PR DESCRIPTION
This PR adds support for setting `priorityClassName` on the Flux and memcached pods.