### PR TITLE
Fixing Helm operator docs link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Welcome to the Flux documentation!
 .. toctree::
    :caption: Helm Operator
 
-   Documentation <https://docs.fluxcd.io/projects/helm-operator>
+   Documentation <https://docs.fluxcd.io/projects/helm-operator/>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The link of https://docs.fluxcd.io/projects/helm-operator/ is a
redirect to https://docs.fluxcd.io/projects/helm-operator/[LANG]/[VERSION]/
for example you get a link like
https://docs.fluxcd.io/projects/helm-operator/en/1.0.0-rc9/

But, when the trailing / is missing the redirect does not happen
and the user gets a 404.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
