### PR TITLE
fix: update pluralization of yaml to non-disputable version

### DIFF
--- a/pkg/cluster/kubernetes/resource/load.go
+++ b/pkg/cluster/kubernetes/resource/load.go
@@ -30,7 +30,7 @@ func Load(base string, paths []string, sopsEnabled bool) (map[string]KubeManifes
 	for _, root := range paths {
 		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return errors.Wrapf(err, "walking %q for yamels", path)
+				return errors.Wrapf(err, "walking %q for yaml files", path)
 			}
 
 			if charts.isDirChart(path) {


### PR DESCRIPTION
# Changelog version

This PR updates the pluralization of YAML in an error message from „yamels“ to „yaml files“.

# Long version

We were debugging an issue with failing git repository clones today. While doing so, the pluralization of „yaml“ to „yamels“ was bugging me extremely, so I thought about a version of it that was possibly agreeable to more people. 

Therefore, I changed it to „yaml files“.