### PR TITLE
Deprecate fluxctl install in favour of fluxctl base-config

### DIFF
--- a/cmd/fluxctl/baseconfig_cmd.go
+++ b/cmd/fluxctl/baseconfig_cmd.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fluxcd/flux/pkg/install"
+)
+
+type baseConfigOpts struct {
+	install.TemplateParameters
+	outputDir string
+}
+
+func newBaseConfig() *baseConfigOpts {
+	return &baseConfigOpts{}
+}
+
+func baseConfigFlags(opts *baseConfigOpts, cmd *cobra.Command) {
+	cmd.Flags().StringVar(&opts.GitURL, "git-url", "",
+		"URL of the Git repository to be used by Flux, e.g. git@github.com:<your username>/flux-get-started")
+	cmd.Flags().StringVar(&opts.GitBranch, "git-branch", "master",
+		"Git branch to be used by Flux")
+	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-paths", []string{},
+		"relative paths within the Git repo for Flux to locate Kubernetes manifests")
+	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-path", []string{},
+		"relative paths within the Git repo for Flux to locate Kubernetes manifests")
+	cmd.Flags().StringVar(&opts.GitLabel, "git-label", "flux",
+		"Git label to keep track of Flux's sync progress; overrides both --git-sync-tag and --git-notes-ref")
+	cmd.Flags().StringVar(&opts.GitUser, "git-user", "Flux",
+		"username to use as git committer")
+	cmd.Flags().StringVar(&opts.GitEmail, "git-email", "",
+		"email to use as git committer")
+	cmd.Flags().BoolVar(&opts.GitReadOnly, "git-readonly", false,
+		"tell flux it has readonly access to the repo")
+	cmd.Flags().BoolVar(&opts.ManifestGeneration, "manifest-generation", false,
+		"whether to enable manifest generation")
+	cmd.Flags().StringVar(&opts.Namespace, "namespace", "",
+		"cluster namespace where to install flux")
+	cmd.Flags().BoolVar(&opts.RegistryDisableScanning, "registry-disable-scanning", false,
+		"do not scan container image registries to fill in the registry cache")
+	cmd.Flags().StringVarP(&opts.outputDir, "output-dir", "o", "", "a directory in which to write individual manifests, rather than printing to stdout")
+	cmd.Flags().BoolVar(&opts.AddSecurityContext, "add-security-context", true, "Ensure security context information is added to the pod specs. Defaults to 'true'")
+}
+
+func (opts *baseConfigOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "base-config",
+		Short: "Print and tweak Kubernetes base manifests needed to install Flux in a Cluster",
+		Example: `# Install Flux and make it use Git repository git@github.com:<your username>/flux-get-started
+fluxctl base-config --git-url 'git@github.com:<your username>/flux-get-started' --git-email=<your_git_email> | kubectl -f -
+
+# Write a base configuration as files ready for kustomization, into the directory base/
+fluxctl base-config --git-url <url> --git-email <email> -o base/
+`,
+		RunE: opts.RunE,
+	}
+	baseConfigFlags(opts, cmd)
+
+	return cmd
+}
+
+func (opts *baseConfigOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return errorWantedNoArgs
+	}
+	if opts.GitURL == "" {
+		return fmt.Errorf("please supply a valid --git-url argument")
+	}
+	if opts.GitEmail == "" {
+		return fmt.Errorf("please supply a valid --git-email argument")
+	}
+	opts.TemplateParameters.Namespace = getKubeConfigContextNamespaceOrDefault(opts.Namespace, "default", "")
+	manifests, err := install.FillInTemplates(opts.TemplateParameters)
+	if err != nil {
+		return err
+	}
+
+	writeManifest := func(fileName string, content []byte) error {
+		_, err := os.Stdout.Write(content)
+		return err
+	}
+
+	if opts.outputDir != "" {
+		info, err := os.Stat(opts.outputDir)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s is not a directory", opts.outputDir)
+		}
+		writeManifest = func(fileName string, content []byte) error {
+			path := filepath.Join(opts.outputDir, fileName)
+			fmt.Fprintf(os.Stderr, "writing %s\n", path)
+			return ioutil.WriteFile(path, content, os.FileMode(0666))
+		}
+	}
+
+	for fileName, content := range manifests {
+		if err := writeManifest(fileName, content); err != nil {
+			return fmt.Errorf("cannot output manifest file %s: %s", fileName, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/fluxctl/baseconfig_cmd_test.go
+++ b/cmd/fluxctl/baseconfig_cmd_test.go
@@ -14,7 +14,7 @@ func TestInstallCommand_ExtraArgumentFailure(t *testing.T) {
 		{"foo", "bar", "bizz", "buzz"},
 	} {
 		t.Run(fmt.Sprintf("%d", k), func(t *testing.T) {
-			cmd := newInstall().Command()
+			cmd := newBaseConfig().Command()
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetArgs(v)
@@ -33,7 +33,7 @@ func TestInstallCommand_MissingRequiredFlag(t *testing.T) {
 		"git-email": "testcase@weave.works",
 	} {
 		t.Run(fmt.Sprintf("only --%s", k), func(t *testing.T) {
-			cmd := newInstall().Command()
+			cmd := newBaseConfig().Command()
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetArgs([]string{})
@@ -50,7 +50,7 @@ func TestInstallCommand_Success(t *testing.T) {
 	f["git-url"] = "git@github.com:testcase/flux-get-started"
 	f["git-email"] = "testcase@weave.works"
 
-	cmd := newInstall().Command()
+	cmd := newBaseConfig().Command()
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{})

--- a/cmd/fluxctl/install_cmd.go
+++ b/cmd/fluxctl/install_cmd.go
@@ -1,57 +1,25 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	"github.com/spf13/cobra"
-
-	"github.com/fluxcd/flux/pkg/install"
 )
 
 type installOpts struct {
-	install.TemplateParameters
-	outputDir string
+	*baseConfigOpts
 }
 
 func newInstall() *installOpts {
-	return &installOpts{}
+	return &installOpts{baseConfigOpts: newBaseConfig()}
 }
 
 func (opts *installOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Print and tweak Kubernetes manifests needed to install Flux in a Cluster",
-		Example: `# Install Flux and make it use Git repository git@github.com:<your username>/flux-get-started
-fluxctl install --git-url 'git@github.com:<your username>/flux-get-started' --git-email=<your_git_email> | kubectl -f -`,
-		RunE: opts.RunE,
+		Use:        "install",
+		Deprecated: "please use base-config",
+		Short:      "Print and tweak Kubernetes manifests needed to install Flux in a Cluster",
+		RunE:       opts.RunE,
 	}
-	cmd.Flags().StringVar(&opts.GitURL, "git-url", "",
-		"URL of the Git repository to be used by Flux, e.g. git@github.com:<your username>/flux-get-started")
-	cmd.Flags().StringVar(&opts.GitBranch, "git-branch", "master",
-		"Git branch to be used by Flux")
-	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-paths", []string{},
-		"relative paths within the Git repo for Flux to locate Kubernetes manifests")
-	cmd.Flags().StringSliceVar(&opts.GitPaths, "git-path", []string{},
-		"relative paths within the Git repo for Flux to locate Kubernetes manifests")
-	cmd.Flags().StringVar(&opts.GitLabel, "git-label", "flux",
-		"Git label to keep track of Flux's sync progress; overrides both --git-sync-tag and --git-notes-ref")
-	cmd.Flags().StringVar(&opts.GitUser, "git-user", "Flux",
-		"username to use as git committer")
-	cmd.Flags().StringVar(&opts.GitEmail, "git-email", "",
-		"email to use as git committer")
-	cmd.Flags().BoolVar(&opts.GitReadOnly, "git-readonly", false,
-		"tell flux it has readonly access to the repo")
-	cmd.Flags().BoolVar(&opts.ManifestGeneration, "manifest-generation", false,
-		"whether to enable manifest generation")
-	cmd.Flags().StringVar(&opts.Namespace, "namespace", "",
-		"cluster namespace where to install flux")
-	cmd.Flags().BoolVar(&opts.RegistryDisableScanning, "registry-disable-scanning", false,
-		"do not scan container image registries to fill in the registry cache")
-	cmd.Flags().StringVarP(&opts.outputDir, "output-dir", "o", "", "a directory in which to write individual manifests, rather than printing to stdout")
-	cmd.Flags().BoolVar(&opts.AddSecurityContext, "add-security-context", true, "Ensure security context information is added to the pod specs. Defaults to 'true'")
+	baseConfigFlags(opts.baseConfigOpts, cmd)
 
 	// Hide and deprecate "git-paths", which was wrongly introduced since its inconsistent with fluxd's git-path flag
 	cmd.Flags().MarkHidden("git-paths")
@@ -61,46 +29,5 @@ fluxctl install --git-url 'git@github.com:<your username>/flux-get-started' --gi
 }
 
 func (opts *installOpts) RunE(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return errorWantedNoArgs
-	}
-	if opts.GitURL == "" {
-		return fmt.Errorf("please supply a valid --git-url argument")
-	}
-	if opts.GitEmail == "" {
-		return fmt.Errorf("please supply a valid --git-email argument")
-	}
-	opts.TemplateParameters.Namespace = getKubeConfigContextNamespaceOrDefault(opts.Namespace, "default", "")
-	manifests, err := install.FillInTemplates(opts.TemplateParameters)
-	if err != nil {
-		return err
-	}
-
-	writeManifest := func(fileName string, content []byte) error {
-		_, err := os.Stdout.Write(content)
-		return err
-	}
-
-	if opts.outputDir != "" {
-		info, err := os.Stat(opts.outputDir)
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("%s is not a directory", opts.outputDir)
-		}
-		writeManifest = func(fileName string, content []byte) error {
-			path := filepath.Join(opts.outputDir, fileName)
-			fmt.Fprintf(os.Stderr, "writing %s\n", path)
-			return ioutil.WriteFile(path, content, os.FileMode(0666))
-		}
-	}
-
-	for fileName, content := range manifests {
-		if err := writeManifest(fileName, content); err != nil {
-			return fmt.Errorf("cannot output manifest file %s: %s", fileName, err)
-		}
-	}
-
-	return nil
+	return opts.baseConfigOpts.RunE(cmd, args)
 }

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -97,6 +97,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		newIdentity(opts).Command(),
 		newSync(opts).Command(),
 		newInstall().Command(),
+		newBaseConfig().Command(),
 		newCompletionCommand(),
 	)
 


### PR DESCRIPTION
Lately we have had requests to add flags to `fluxctl install` for
various options; this indicates people would like a non-Helm way to
install flux.

However `fluxctl install` isn't really it -- flags are not a good way
to control the complexity of even a modest Kubernetes configuration
like Flux's.

A better thing to do is to give people a way to get a workable base
config which they can then customise -- indeed, kustomize -- to their
hearts' content.

This commit in effect renames `fluxctl install` to `fluxctl
base-config`, to make it clearer that the expected use is to generate
a base config for further modification. `fluxctl install` remains, for
backward-compatibility, but outputs a deprecation notice to stderr.

TODO:
 - [ ] update docs that refer to `fluxctl install`
 - [ ] consider adding howtos for using `fluxctl base-config` with kustomize (e.g., to cover https://github.com/fluxcd/flux/issues/2541)