### PR TITLE
Add memcached resource requests

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -44,7 +44,11 @@ clusterRole:
   # true, a name based on fullname is generated
   name:
 
-resources:
+resources:  
+  # If you do want to specify resource limits, uncomment the following and adjust values
+  # limits:
+  #  cpu: 100m
+  #  memory: 628Mi
   requests:
     cpu: 50m
     memory: 64Mi
@@ -201,15 +205,14 @@ memcached:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  resources: {}
-    # If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  resources:
+    # If you do want to specify resource limits, uncomment the following and adjust values
     # limits:
     #  cpu: 100m
     #  memory: 628Mi
-    # requests:
-    #  cpu: 50m
-    #  memory: 512Mi
+    requests:
+     cpu: 50m
+     memory: 64Mi
   priorityClassName: ""
 
 ssh:


### PR DESCRIPTION
- Adding in default resource limits for the helm chart to follow k8s best practices.
- Memcached should at least have a request block by default.