### PR TITLE
Updated helm operator CRD URL in the documentation

### DIFF
--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -58,7 +58,7 @@ helm repo add fluxcd https://charts.fluxcd.io
 Apply the Helm Release CRD:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/flux-helm-release-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/helm-operator-crds.yaml
 ```
 
 In this next step you install Flux using `helm`. Simply

--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -58,7 +58,7 @@ helm repo add fluxcd https://charts.fluxcd.io
 Apply the Helm Release CRD:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/helm-operator-crds.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
 ```
 
 In this next step you install Flux using `helm`. Simply


### PR DESCRIPTION
Hi there,

A quick PR to update the helm operator CRD URL in the documentation due to https://github.com/fluxcd/helm-operator/pull/270 (change in file name).

I just had a 404 not found on the previous URL this morning.


