### PR TITLE
Updating Docs to ignore workloads

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -327,7 +327,7 @@ Yes. The easiest way to do that is to use the following annotation in the manife
 the change to git:
 
 ```yaml
-    fluxcd.io/ignore: true
+    flux.weave.works/ignore: true
 ```
 
 To stop ignoring these annotated resources, you simply remove the annotation from the manifests in git.

--- a/docs/references/fluxctl.md
+++ b/docs/references/fluxctl.md
@@ -710,4 +710,4 @@ Things to notice:
 3. The value for the `fluxcd.io/tag.`... annotation should includes the filter pattern type, in this case `semver`.
 
 Annotations can also be used to tell Flux to temporarily ignore certain manifests
-using `fluxcd.io/ignore: "true"`. Read more about this in the [FAQ](../faq.md).
+using `flux.weave.works/ignore: "true"`. Read more about this in the [FAQ](../faq.md).


### PR DESCRIPTION
`fluxcd.io/ignore` has been deprecated but doc still points to it: the right group should be `flux.weave.works/ignore`

Related to #2857
