### PR TITLE
#2905 Allow changing workload scale with release command:

### DIFF
--- a/cmd/fluxctl/error.go
+++ b/cmd/fluxctl/error.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 )
 
 type usageError struct {
@@ -12,20 +13,35 @@ func newUsageError(msg string) usageError {
 	return usageError{error: errors.New(msg)}
 }
 
-func checkExactlyOne(optsDescription string, supplied ...bool) error {
-	found := false
-	for _, s := range supplied {
-		if found && s {
-			return newUsageError("please supply only one of " + optsDescription)
-		}
-		found = found || s
+func checkExactly(optsDescription string, desired int, supplied ...bool) error {
+	if countTrue(supplied) != desired {
+		return newUsageError(fmt.Sprintf("please supply exactly %d of %s", desired, optsDescription))
 	}
-
-	if !found {
-		return newUsageError("please supply exactly one of " + optsDescription)
-	}
-
 	return nil
+}
+
+func checkAtMost(optsDescription string, atMost int, supplied ...bool) error {
+	if countTrue(supplied) > atMost {
+		return newUsageError(fmt.Sprintf("please supply at most %d of %s", atMost, optsDescription))
+	}
+	return nil
+}
+
+func checkAtLeast(optsDescription string, atLeast int, supplied ...bool) error {
+	if countTrue(supplied) < atLeast {
+		return newUsageError(fmt.Sprintf("please supply at most %d of %s", atLeast, optsDescription))
+	}
+	return nil
+}
+
+func countTrue(supplied []bool) int {
+	truecount := 0
+	for _, s := range supplied {
+		if s {
+			truecount += 1
+		}
+	}
+	return truecount
 }
 
 var errorWantedNoArgs = newUsageError("expected no (non-flag) arguments")

--- a/cmd/fluxctl/format.go
+++ b/cmd/fluxctl/format.go
@@ -170,18 +170,18 @@ func outputWorkloadsJson(workloads []v6.ControllerStatus, out io.Writer) error {
 func outputWorkloadsTab(workloads []v6.ControllerStatus, opts *workloadListOpts) {
 	w := newTabwriter()
 	if !opts.noHeaders {
-		fmt.Fprintf(w, "WORKLOAD\tCONTAINER\tIMAGE\tRELEASE\tPOLICY\n")
+		fmt.Fprintf(w, "WORKLOAD\tCONTAINER\tIMAGE\tREPLICAS\tRELEASE\tPOLICY\n")
 	}
 
 	for _, workload := range workloads {
 		if len(workload.Containers) > 0 {
 			c := workload.Containers[0]
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", workload.ID, c.Name, c.Current.ID, workload.Status, policies(workload))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n", workload.ID, c.Name, c.Current.ID, workload.Rollout.Desired, workload.Status, policies(workload))
 			for _, c := range workload.Containers[1:] {
 				fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t\t\t%s\t%s\n", workload.ID, workload.Status, policies(workload))
+			fmt.Fprintf(w, "%s\t\t\t%d\t%s\t%s\n", workload.ID, workload.Rollout.Desired, workload.Status, policies(workload))
 		}
 	}
 	w.Flush()

--- a/cmd/fluxctl/list_workloads_cmd_test.go
+++ b/cmd/fluxctl/list_workloads_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,16 +16,50 @@ import (
 	v6 "github.com/fluxcd/flux/pkg/api/v6"
 )
 
+const replicas int = 1
+
+var expectedJson = "[" +
+	"{\"ID\":\"applications:deployment/mah-app-0\",\"Containers\":null,\"ReadOnly\":\"\",\"Status\":\"ready\"," +
+	"\"Rollout\":{\"Desired\":" + strconv.Itoa(replicas) + ",\"Updated\":0,\"Ready\":0,\"Available\":0,\"Outdated\":0,\"Messages\":null}," +
+	"\"SyncError\":\"\",\"Antecedent\":\"\",\"Labels\":null,\"Automated\":false,\"Locked\":false,\"Ignore\":false," +
+	"\"Policies\":null}," +
+	"{\"ID\":\"applications:deployment/mah-app-1\",\"Containers\":null,\"ReadOnly\":\"\",\"Status\":\"ready\"," +
+	"\"Rollout\":{\"Desired\":" + strconv.Itoa(replicas) + ",\"Updated\":0,\"Ready\":0,\"Available\":0,\"Outdated\":0,\"Messages\":null}," +
+	"\"SyncError\":\"\",\"Antecedent\":\"\",\"Labels\":null,\"Automated\":false,\"Locked\":false,\"Ignore\":false,\"Policies\":null}," +
+	"{\"ID\":\"applications:deployment/mah-app-2\",\"Containers\":null,\"ReadOnly\":\"\",\"Status\":\"ready\"," +
+	"\"Rollout\":{\"Desired\":" + strconv.Itoa(replicas) + ",\"Updated\":0,\"Ready\":0,\"Available\":0,\"Outdated\":0,\"Messages\":null}," +
+	"\"SyncError\":\"\",\"Antecedent\":\"\",\"Labels\":null,\"Automated\":false,\"Locked\":false,\"Ignore\":false,\"Policies\":null}," +
+	"{\"ID\":\"applications:deployment/mah-app-3\",\"Containers\":null,\"ReadOnly\":\"\",\"Status\":\"ready\"," +
+	"\"Rollout\":{\"Desired\":" + strconv.Itoa(replicas) + ",\"Updated\":0,\"Ready\":0,\"Available\":0,\"Outdated\":0,\"Messages\":null}," +
+	"\"SyncError\":\"\",\"Antecedent\":\"\",\"Labels\":null,\"Automated\":false,\"Locked\":false,\"Ignore\":false,\"Policies\":null}," +
+	"{\"ID\":\"applications:deployment/mah-app-4\",\"Containers\":null,\"ReadOnly\":\"\",\"Status\":\"ready\"," +
+	"\"Rollout\":{\"Desired\":" + strconv.Itoa(replicas) + ",\"Updated\":0,\"Ready\":0,\"Available\":0,\"Outdated\":0,\"Messages\":null}," +
+	"\"SyncError\":\"\",\"Antecedent\":\"\",\"Labels\":null,\"Automated\":false,\"Locked\":false,\"Ignore\":false,\"Policies\":null}]\n"
+
 func Test_outputWorkloadsJson(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	t.Run("sends JSON to the io.Writer", func(t *testing.T) {
 		workloads := testWorkloads(5)
 		err := outputWorkloadsJson(workloads, buf)
+		if fmt.Sprint(buf) != expectedJson {
+			t.Errorf("It did not get expected result:\n\n%s\n\nInstead got:\n\n%s", expectedJson, fmt.Sprint(buf))
+		}
 		require.NoError(t, err)
 		unmarshallTarget := &[]v6.ControllerStatus{}
 		err = json.Unmarshal(buf.Bytes(), unmarshallTarget)
 		require.NoError(t, err)
+	})
+}
+
+func Test_outputWorkloadsTab(t *testing.T) {
+	var opts *workloadListOpts = &workloadListOpts{
+		noHeaders: false,
+	}
+
+	t.Run("sends Tab to the io.Writer", func(t *testing.T) {
+		workloads := testWorkloads(5)
+		outputWorkloadsTab(workloads, opts)
 	})
 }
 
@@ -33,13 +68,14 @@ func testWorkloads(workloadCount int) []v6.ControllerStatus {
 	for i := 0; i < workloadCount; i++ {
 		name := fmt.Sprintf("mah-app-%d", i)
 		id := resource.MakeID("applications", "deployment", name)
-
 		cs := v6.ControllerStatus{
 			ID:         id,
 			Containers: nil,
 			ReadOnly:   "",
 			Status:     "ready",
-			Rollout:    cluster.RolloutStatus{},
+			Rollout: cluster.RolloutStatus{
+				Desired: 1,
+			},
 			SyncError:  "",
 			Antecedent: resource.ID{},
 			Labels:     nil,

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -50,6 +50,7 @@ Workflow:
   fluxctl list-workloads                                                   # Which workloads are running?
   fluxctl list-images --workload=default:deployment/foo                    # Which images are running/available?
   fluxctl release --workload=default:deployment/foo --update-image=bar:v2  # Release new version.
+  fluxctl release --workload=default:deployment/foo --update-scale=3       # Scale pods
 `)
 
 const (

--- a/docs/references/fluxctl.md
+++ b/docs/references/fluxctl.md
@@ -203,6 +203,7 @@ Workflow:
   fluxctl list-workloads                                                   # Which workloads are running?
   fluxctl list-images --workload=default:deployment/foo                    # Which images are running/available?
   fluxctl release --workload=default:deployment/foo --update-image=bar:v2  # Release new version.
+  fluxctl release --workload=default:deployment/foo --update-scale=3       # Scale workload.
 
 Usage:
   fluxctl [command]

--- a/docs/references/fluxyaml-config-files.md
+++ b/docs/references/fluxyaml-config-files.md
@@ -332,6 +332,9 @@ environment variables, when executed:
    * `FLUX_IMG`: Image name which the container needs to be updated to (e.g. `nginx`).
    * `FLUX_TAG`: Image tag which the container needs to be updated to (e.g. `1.15`).
 
+ * `scale` updaters are provided with:
+   * `FLUX_SCALE`: Number of replicas to set for the the workload which needs to be updated.
+
  * `policy` updaters are provided with:
    * `FLUX_POLICY`: the name of the policy to be added or updated in
      the workload. To make into an annotation name, prefix with

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -75,8 +75,8 @@ type Workload struct {
 	Rollout    RolloutStatus
 	// Errors during the recurring sync from the Git repository to the
 	// cluster will surface here.
-	SyncError error
-
+	SyncError  error
+	Replicas   *int32
 	Containers ContainersOrExcuse
 }
 

--- a/pkg/cluster/kubernetes/errors.go
+++ b/pkg/cluster/kubernetes/errors.go
@@ -17,7 +17,7 @@ perhaps verify its presence using kubectl.
 `, obj)}
 }
 
-func UpdateNotSupportedError(kind string) *fluxerr.Error {
+func ImageUpdateNotSupportedError(kind string) *fluxerr.Error {
 	return &fluxerr.Error{
 		Type: fluxerr.User,
 		Err:  fmt.Errorf("updating resource kind %q not supported", kind),
@@ -26,6 +26,23 @@ func UpdateNotSupportedError(kind string) *fluxerr.Error {
 This may be because those resources do not use images, you are trying
 to use a YAML dot notation path annotation for a non HelmRelease
 resource, or because it is a new kind of resource in Kubernetes, and
+Flux does not support it yet.
+
+If you can use a Deployment instead, Flux can work with
+those. Otherwise, you may have to update the resource manually (e.g.,
+using kubectl).
+`,
+	}
+}
+
+func ScaleUpdateNotSupportedError(kind string) *fluxerr.Error {
+	return &fluxerr.Error{
+		Type: fluxerr.User,
+		Err:  fmt.Errorf("updating resource kind %q not supported", kind),
+		Help: `Flux does not support updating scale for ` + kind + ` resources.
+
+This may be because those resources do not use scale, or because
+it is a new kind of resource in Kubernetes, and
 Flux does not support it yet.
 
 If you can use a Deployment instead, Flux can work with

--- a/pkg/cluster/kubernetes/manifests.go
+++ b/pkg/cluster/kubernetes/manifests.go
@@ -172,6 +172,18 @@ func (m *manifests) SetWorkloadContainerImage(def []byte, id resource.ID, contai
 	return updateWorkloadContainer(def, id, container, image)
 }
 
+func (m *manifests) SetWorkloadScale(def []byte, id resource.ID, newReplicas int) ([]byte, error) {
+	resources, err := m.ParseManifest(def, "stdin")
+	if err != nil {
+		return nil, err
+	}
+	_, ok := resources[id.String()]
+	if !ok {
+		return nil, fmt.Errorf("resource %s not found", id.String())
+	}
+	return updateWorkloadScale(def, id, newReplicas)
+}
+
 func (m *manifests) CreateManifestPatch(originalManifests, modifiedManifests []byte, originalSource, modifiedSource string) ([]byte, error) {
 	return createManifestPatch(originalManifests, modifiedManifests, originalSource, modifiedSource)
 }

--- a/pkg/cluster/kubernetes/resource/deployment.go
+++ b/pkg/cluster/kubernetes/resource/deployment.go
@@ -23,4 +23,12 @@ func (d Deployment) SetContainerImage(container string, ref image.Ref) error {
 	return d.Spec.Template.SetContainerImage(container, ref)
 }
 
+func (d Deployment) GetReplicas() int {
+	return d.Spec.Replicas
+}
+
+func (d Deployment) SetReplicas(replicas int) {
+	d.Spec.Replicas = replicas
+}
+
 var _ resource.Workload = Deployment{}

--- a/pkg/cluster/kubernetes/resource/statefulset.go
+++ b/pkg/cluster/kubernetes/resource/statefulset.go
@@ -23,4 +23,12 @@ func (ss StatefulSet) SetContainerImage(container string, ref image.Ref) error {
 	return ss.Spec.Template.SetContainerImage(container, ref)
 }
 
+func (ss StatefulSet) GetReplicas() int {
+	return ss.Spec.Replicas
+}
+
+func (ss StatefulSet) SetReplicas(replicas int) {
+	ss.Spec.Replicas = replicas
+}
+
 var _ resource.Workload = StatefulSet{}

--- a/pkg/cluster/kubernetes/resourcekinds.go
+++ b/pkg/cluster/kubernetes/resourcekinds.go
@@ -51,6 +51,7 @@ func init() {
 type workload struct {
 	k8sObject
 	status      string
+	replicas    *int32
 	rollout     cluster.RolloutStatus
 	syncError   error
 	podTemplate apiv1.PodTemplateSpec
@@ -107,6 +108,7 @@ func (w workload) toClusterWorkload(resourceID resource.ID) cluster.Workload {
 		Labels:     w.GetLabels(),
 		Policies:   policies,
 		Containers: cluster.ContainersOrExcuse{Containers: clusterContainers, Excuse: excuse},
+		Replicas:   w.replicas,
 	}
 }
 
@@ -189,6 +191,7 @@ func makeDeploymentWorkload(deployment *apiapps.Deployment) workload {
 	return workload{
 		status:      status,
 		rollout:     rollout,
+		replicas:    deployment.Spec.Replicas,
 		podTemplate: deployment.Spec.Template,
 		k8sObject:   deployment}
 }
@@ -355,6 +358,7 @@ func makeStatefulSetWorkload(statefulSet *apiapps.StatefulSet) workload {
 	return workload{
 		status:      status,
 		rollout:     rollout,
+		replicas:    statefulSet.Spec.Replicas,
 		podTemplate: statefulSet.Spec.Template,
 		k8sObject:   statefulSet}
 }

--- a/pkg/cluster/mock/mock.go
+++ b/pkg/cluster/mock/mock.go
@@ -21,6 +21,7 @@ type Mock struct {
 	SyncFunc                      func(cluster.SyncSet) error
 	PublicSSHKeyFunc              func(regenerate bool) (ssh.PublicKey, error)
 	SetWorkloadContainerImageFunc func(def []byte, id resource.ID, container string, newImageID image.Ref) ([]byte, error)
+	SetWorkloadScaleFunc          func(def []byte, id resource.ID, newReplicas int) ([]byte, error)
 	LoadManifestsFunc             func(base string, paths []string) (map[string]resource.Resource, error)
 	ParseManifestFunc             func(def []byte, source string) (map[string]resource.Resource, error)
 	UpdateWorkloadPoliciesFunc    func([]byte, resource.ID, resource.PolicyUpdate) ([]byte, error)
@@ -62,6 +63,10 @@ func (m *Mock) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
 
 func (m *Mock) SetWorkloadContainerImage(def []byte, id resource.ID, container string, newImageID image.Ref) ([]byte, error) {
 	return m.SetWorkloadContainerImageFunc(def, id, container, newImageID)
+}
+
+func (m *Mock) SetWorkloadScale(def []byte, id resource.ID, newReplicas int) ([]byte, error) {
+	return m.SetWorkloadScale(def, id, newReplicas)
 }
 
 func (m *Mock) LoadManifests(baseDir string, paths []string) (map[string]resource.Resource, error) {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -20,6 +20,8 @@ type Manifests interface {
 	ParseManifest(def []byte, source string) (map[string]resource.Resource, error)
 	// Set the image of a container in a manifest's bytes to that given
 	SetWorkloadContainerImage(def []byte, resourceID resource.ID, container string, newImageID image.Ref) ([]byte, error)
+	// Set the scale of a resource in the store
+	SetWorkloadScale(def []byte, id resource.ID, newReplicas int) ([]byte, error)
 	// UpdateWorkloadPolicies modifies a manifest to apply the policy update specified
 	UpdateWorkloadPolicies(def []byte, id resource.ID, update resource.PolicyUpdate) ([]byte, error)
 	// CreateManifestPatch obtains a patch between the original and modified manifests

--- a/pkg/manifests/rawfiles.go
+++ b/pkg/manifests/rawfiles.go
@@ -57,6 +57,36 @@ func (f *rawFiles) setManifestWorkloadContainerImage(r resource.Resource, contai
 	return ioutil.WriteFile(fullFilePath, newDef, fi.Mode())
 }
 
+// Set the container scale of a resource in the store
+func (f *rawFiles) SetWorkloadScale(ctx context.Context, id resource.ID, newReplicas int) error {
+	resourcesByID, err := f.GetAllResourcesByID(ctx)
+	if err != nil {
+		return err
+	}
+	r, ok := resourcesByID[id.String()]
+	if !ok {
+		return ErrResourceNotFound(id.String())
+	}
+	return f.setManifestWorkloadScale(r, newReplicas)
+}
+
+func (f *rawFiles) setManifestWorkloadScale(r resource.Resource, newReplicas int) error {
+	fullFilePath := filepath.Join(f.baseDir, r.Source())
+	def, err := ioutil.ReadFile(fullFilePath)
+	if err != nil {
+		return err
+	}
+	newDef, err := f.manifests.SetWorkloadScale(def, r.ResourceID(), newReplicas)
+	if err != nil {
+		return err
+	}
+	fi, err := os.Stat(fullFilePath)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(fullFilePath, newDef, fi.Mode())
+}
+
 // UpdateWorkloadPolicies modifies a resource in the store to apply the policy-update specified.
 // It returns whether a change in the resource was actually made as a result of the change
 func (f *rawFiles) UpdateWorkloadPolicies(ctx context.Context, id resource.ID, update resource.PolicyUpdate) (bool, error) {

--- a/pkg/manifests/store.go
+++ b/pkg/manifests/store.go
@@ -21,6 +21,8 @@ func ErrResourceNotFound(name string) error {
 type Store interface {
 	// Set the container image of a resource in the store
 	SetWorkloadContainerImage(ctx context.Context, resourceID resource.ID, container string, newImageID image.Ref) error
+	// Set the scale of a resource in the store
+	SetWorkloadScale(ctx context.Context, resourceID resource.ID, newReplicas int) error
 	// UpdateWorkloadPolicies modifies a resource in the store to apply the policy-update specified.
 	// It returns whether a change in the resource was actually made as a result of the change
 	UpdateWorkloadPolicies(ctx context.Context, resourceID resource.ID, update resource.PolicyUpdate) (bool, error)

--- a/pkg/release/context.go
+++ b/pkg/release/context.go
@@ -38,10 +38,16 @@ func (rc *ReleaseContext) GetAllResources(ctx context.Context) (map[string]resou
 func (rc *ReleaseContext) WriteUpdates(ctx context.Context, updates []*update.WorkloadUpdate) error {
 	err := func() error {
 		for _, update := range updates {
-			for _, container := range update.Updates {
-				err := rc.resourceStore.SetWorkloadContainerImage(ctx, update.ResourceID, container.Container, container.Target)
+			for _, containerUpdate := range update.ContainerUpdates {
+				err := rc.resourceStore.SetWorkloadContainerImage(ctx, update.ResourceID, containerUpdate.Container, containerUpdate.Target)
 				if err != nil {
-					return errors.Wrapf(err, "updating resource %s in %s", update.ResourceID.String(), update.Resource.Source())
+					return errors.Wrapf(err, "updating container image for resource %s in %s", update.ResourceID.String(), update.Resource.Source())
+				}
+			}
+			if update.ScaleUpdate != nil {
+				err := rc.resourceStore.SetWorkloadScale(ctx, update.ResourceID, update.ScaleUpdate.Target)
+				if err != nil {
+					return errors.Wrapf(err, "updating scale for resource %s in %s", update.ResourceID.String(), update.Resource.Source())
 				}
 			}
 		}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -26,3 +26,8 @@ type Workload interface {
 	// effect on any underlying file or cluster resource.
 	SetContainerImage(container string, ref image.Ref) error
 }
+
+type Scalable interface {
+	GetReplicas() int
+	SetReplicas(replicas int)
+}

--- a/pkg/update/automated.go
+++ b/pkg/update/automated.go
@@ -121,7 +121,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Workl
 		}
 
 		if len(containerUpdates) > 0 {
-			u.Updates = containerUpdates
+			u.ContainerUpdates = containerUpdates
 			updates = append(updates, u)
 			result[u.ResourceID] = WorkloadResult{
 				Status:       ReleaseStatusSuccess,

--- a/pkg/update/release_containers.go
+++ b/pkg/update/release_containers.go
@@ -145,12 +145,12 @@ func (s ReleaseContainersSpec) workloadUpdates(results Result, all []*WorkloadUp
 				// container mismatched.
 				rerr = mismatchError
 			}
-			u.Updates = containerUpdates
+			u.ContainerUpdates = containerUpdates
 			updates = append(updates, u)
 			results[u.ResourceID] = WorkloadResult{
 				Status:       ReleaseStatusSuccess,
 				Error:        rerr,
-				PerContainer: u.Updates,
+				PerContainer: u.ContainerUpdates,
 			}
 		}
 	}

--- a/pkg/update/result.go
+++ b/pkg/update/result.go
@@ -89,3 +89,8 @@ type ContainerUpdate struct {
 	Current   image.Ref
 	Target    image.Ref
 }
+
+type ScaleUpdate struct {
+	Current int
+	Target  int
+}

--- a/pkg/update/workload.go
+++ b/pkg/update/workload.go
@@ -6,10 +6,11 @@ import (
 )
 
 type WorkloadUpdate struct {
-	ResourceID resource.ID
-	Workload   cluster.Workload
-	Resource   resource.Workload
-	Updates    []ContainerUpdate
+	ResourceID       resource.ID
+	Workload         cluster.Workload
+	Resource         resource.Workload
+	ContainerUpdates []ContainerUpdate
+	ScaleUpdate      *ScaleUpdate
 }
 
 type WorkloadFilter interface {


### PR DESCRIPTION
Added number of replicas to list-workloads to view current scale
Added --update-scale flag to be able to track replicas in scm

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
