### PR TITLE
Add ssh-keygen key format option

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -189,6 +189,7 @@ spec:
           - --log-format={{ .Values.logFormat }}
           {{end}}
           - --ssh-keygen-dir=/var/fluxd/keygen
+          - --ssh-keygen-format={{ .Values.ssh.keygen.format }}
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
           - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -219,6 +219,13 @@ ssh:
   # Overrides for git over SSH. If you use your own git server, you
   # will likely need to provide a host key for it in this field.
   known_hosts: ""
+  # Specify options for SSH key generation.
+  keygen:
+    # Specify a key format for key generation.
+    # RFC4716” (RFC 4716/SSH2 public or private key),
+    # “PKCS8” (PEM PKCS8 public key) or
+    # “PEM” (PEM public key).
+    format: "RFC4716"
 
 kube:
   # Override for kubectl default config

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -186,6 +186,7 @@ func main() {
 		// SSH key generation
 		sshKeyBits   = optionalVar(fs, &ssh.KeyBitsValue{}, "ssh-keygen-bits", "-b argument to ssh-keygen (default unspecified)")
 		sshKeyType   = optionalVar(fs, &ssh.KeyTypeValue{}, "ssh-keygen-type", "-t argument to ssh-keygen (default unspecified)")
+		sshKeyFormat = optionalVar(fs, &ssh.KeyFormatValue{}, "ssh-keygen-format", "-m argument to ssh-keygen (default RFC4716)")
 		sshKeygenDir = fs.String("ssh-keygen-dir", "", "directory, ideally on a tmpfs volume, in which to generate new SSH keys when necessary")
 
 		// manifest generation
@@ -484,6 +485,7 @@ func main() {
 				SecretDataKey:         *k8sSecretDataKey,
 				KeyBits:               sshKeyBits,
 				KeyType:               sshKeyType,
+				KeyFormat:             sshKeyFormat,
 				KeyGenDir:             *sshKeygenDir,
 			})
 			if err != nil {

--- a/docs/references/daemon.md
+++ b/docs/references/daemon.md
@@ -96,6 +96,7 @@ Version controlling of cluster manifests provides reproducibility and a historic
 | **SSH key generation**
 | --ssh-keygen-bits                                |                                    | -b argument to ssh-keygen (default unspecified)
 | --ssh-keygen-type                                |                                    | -t argument to ssh-keygen (default unspecified)
+| --ssh-keygen-format                              |                                    | -m argument to ssh-keygen (default RFC4716)
 | **manifest generation**
 | --manifest-generation                            | false                              | search for .flux.yaml files to generate manifests
 | --sops                                           | false                              | decrypt SOPS-encrypted manifest files before applying them to the cluster. Provide decryption keys in the same way as providing them for `sops` the binary, for example with `--git-gpg-key-import`. The full description of how to supply sops with a key can be found in the [SOPS documentation](https://github.com/mozilla/sops#usage). Be aware that manifests generated with `.flux.yaml` files are not decrypted. Instead, make sure to output cleartext manifests by explicitly invoking the `sops` binary.

--- a/pkg/cluster/kubernetes/sshkeyring.go
+++ b/pkg/cluster/kubernetes/sshkeyring.go
@@ -31,6 +31,7 @@ type SSHKeyRingConfig struct {
 	SecretDataKey         string // e.g. "identity"
 	KeyBits               ssh.OptionalValue
 	KeyType               ssh.OptionalValue
+	KeyFormat             ssh.OptionalValue
 	KeyGenDir             string // a tmpfs mount; e.g., /var/fluxd/ssh
 }
 
@@ -102,7 +103,7 @@ func (skr *sshKeyRing) KeyPair() (publicKey ssh.PublicKey, privateKeyPath string
 // syscall.Mlockall(MCL_FUTURE) in conjunction with an appropriate ulimit to
 // ensure the private key isn't unintentionally written to persistent storage.
 func (skr *sshKeyRing) Regenerate() error {
-	tmpPrivateKeyPath, privateKey, publicKey, err := ssh.KeyGen(skr.KeyBits, skr.KeyType, skr.KeyGenDir)
+	tmpPrivateKeyPath, privateKey, publicKey, err := ssh.KeyGen(skr.KeyBits, skr.KeyType, skr.KeyFormat, skr.KeyGenDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/ssh/keygen.go
+++ b/pkg/ssh/keygen.go
@@ -78,11 +78,38 @@ func (ktv *KeyTypeValue) Specified() bool {
 	return ktv.specified
 }
 
+// KeyFormatValue is an OptionalValue allowing specification of the -m argument
+// to ssh-keygen.
+type KeyFormatValue struct {
+	specified bool
+	keyFormat string
+}
+
+func (ktv *KeyFormatValue) String() string {
+	return ktv.keyFormat
+}
+
+func (ktv *KeyFormatValue) Set(s string) error {
+	if len(s) > 0 {
+		ktv.keyFormat = s
+		ktv.specified = true
+	}
+	return nil
+}
+
+func (ktv *KeyFormatValue) Type() string {
+	return "string"
+}
+
+func (ktv *KeyFormatValue) Specified() bool {
+	return ktv.specified
+}
+
 // KeyGen generates a new keypair with ssh-keygen, optionally overriding the
 // default type and size. Each generated keypair is written to a new unique
 // subdirectory of tmpfsPath, which should point to a tmpfs mount as the
 // private key is not encrypted.
-func KeyGen(keyBits, keyType OptionalValue, tmpfsPath string) (privateKeyPath string, privateKey []byte, publicKey PublicKey, err error) {
+func KeyGen(keyBits, keyType, keyFormat OptionalValue, tmpfsPath string) (privateKeyPath string, privateKey []byte, publicKey PublicKey, err error) {
 	tempDir, err := ioutil.TempDir(tmpfsPath, "..weave-keygen")
 	if err != nil {
 		return "", nil, PublicKey{}, err
@@ -95,6 +122,9 @@ func KeyGen(keyBits, keyType OptionalValue, tmpfsPath string) (privateKeyPath st
 	}
 	if keyType.Specified() {
 		args = append(args, "-t", keyType.String())
+	}
+	if keyFormat.Specified() {
+		args = append(args, "-m", keyFormat.String())
 	}
 
 	cmd := exec.Command("ssh-keygen", args...)


### PR DESCRIPTION
Adding an option to specify the format of the generate SSH keys using `ssh-keygen` utility. This helps users to better integrate and manage flux installation with existing automation tools which are only able to read certain key format.

For example, Terraform TLS provider is not able to read the default OpenSSH RFC4716 format so being able to change the format on the installation to PEM format solves this issue and makes it trackable by the Terraform state natively. 

I kept the default format in the values file the same, so basically this will not change the default format which Flux uses at installation time. But only add the ability to pick different formats when needed.

For more information check the `-m` option in `man ssh-keygen`