### PR TITLE
[docs] mention new fluxctl arch linux package

### DIFF
--- a/docs/references/fluxctl.md
+++ b/docs/references/fluxctl.md
@@ -38,13 +38,10 @@ instead.
 
 #### Arch Linux
 
-Install the `fluxctl-bin` package [from the
-AUR](https://aur.archlinux.org/packages/fluxctl-bin/):
+Install `fluxctl` via pacman:
 
 ```sh
-git clone https://aur.archlinux.org/fluxctl-bin.git
-cd fluxctl-bin
-makepkg -si
+pacman -S fluxctl
 ```
 
 ### Windows


### PR DESCRIPTION
If applied, this commit will mention the fluxctl package in the official Arch Linux repositories. No need to use the AUR anymore. I have just pushed it to community.

https://www.archlinux.org/packages/community/x86_64/fluxctl/

