### PR TITLE
Store publicKey in secret.

### DIFF
--- a/pkg/cluster/kubernetes/sshkeyring.go
+++ b/pkg/cluster/kubernetes/sshkeyring.go
@@ -119,7 +119,8 @@ func (skr *sshKeyRing) Regenerate() error {
 
 	patch := map[string]map[string]string{
 		"data": map[string]string{
-			"identity": base64.StdEncoding.EncodeToString(privateKey),
+			"identity":     base64.StdEncoding.EncodeToString(privateKey),
+			"identity.pub": base64.StdEncoding.EncodeToString([]byte(publicKey.Key)),
 		},
 	}
 


### PR DESCRIPTION
Storing SSH PublicKey along with the Identity (Private Key) in the secret object in order to make it easier to query, instead of using `fluxctl identity` command or `checking the logs of the fluxd container`. 

This can be useful while integrating the Flux installation with automation tools. 

For example, Terrafrom installs Flux using Helm Provider and then use the Kubernetes provider to get the public key from the secret and store that in Github using github provider.

I understand the PublicKey is not actually a secret, and it could be stored in a ConfigMap for example. But maybe it is more convenient to keep both the Public and Identity keys at the same place.