### PR TITLE
address CVE-2020-6750 for glib

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg gawk socat
+RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' 'glib>=2.62.5-r0' gnupg gawk socat
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing git-secret
 
 # Add git hosts to known hosts file so we can use


### PR DESCRIPTION
Fixes: #2883 

We ran into the same issue of failed security scans. The CVE is resolved in glib 2.62.5-r0+

I saw, and agree with @hiddeco's comment in #2883, about understanding context / threat model. However this seems like a quick fix to help out other folks in the same boat.

Test to validate the package exists:
```
$ docker run --entrypoint "/bin/bash" -it fluxcd/flux:1.18.0
$ export PATH=$PATH:/sbin
$ apk update
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
v3.11.3-130-g227c9b13ac [http://dl-cdn.alpinelinux.org/alpine/v3.11/main]
v3.11.3-127-g6253a98c55 [http://dl-cdn.alpinelinux.org/alpine/v3.11/community]
OK: 11272 distinct packages available
$ apk upgrade glib
(1/7) Upgrading musl (1.1.24-r0 -> 1.1.24-r1)
(2/7) Upgrading ca-certificates-cacert (20191127-r0 -> 20191127-r1)
(3/7) Upgrading ncurses-terminfo-base (6.1_p20191130-r0 -> 6.1_p20200118-r2)
(4/7) Upgrading ncurses-libs (6.1_p20191130-r0 -> 6.1_p20200118-r2)
(5/7) Purging ncurses-terminfo (6.1_p20191130-r0)
(6/7) Upgrading glib (2.62.4-r0 -> 2.62.5-r0)
(7/7) Upgrading musl-utils (1.1.24-r0 -> 1.1.24-r1)
Executing busybox-1.31.1-r9.trigger
OK: 48 MiB in 57 packages
```

Maybe this could land in a patch release?