### PR TITLE
ci: Migrate tests to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
       - run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
       - run: make check-generated
       - run: make all
+      #- run: E2E_KIND_CLUSTER_NUM=4 make e2e
       - run: E2E_KIND_CLUSTER_NUM=4 make e2e
       - save_cache:
           key: cache-{{ checksum "Makefile" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,6 @@ jobs:
       - run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
       - run: make check-generated
       - run: make all
-      #- run: E2E_KIND_CLUSTER_NUM=4 make e2e
-      - run: E2E_KIND_CLUSTER_NUM=4 make e2e
       - save_cache:
           key: cache-{{ checksum "Makefile" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,6 @@ jobs:
           keys:
             - go-mod-{{ checksum "go.mod" }}
             - go-mod-
-      # Note that the test timeout is per Go package
-      - run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
-      - run: make check-generated
       - run: make all
       - save_cache:
           key: cache-{{ checksum "Makefile" }}

--- a/.github/workflows/ci-cleanup.yaml
+++ b/.github/workflows/ci-cleanup.yaml
@@ -1,0 +1,19 @@
+name: artifacts-cleanup
+
+on:
+  schedule:
+    # Every day at 1am
+    - cron: '0 1 * * *'
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Remove old artifacts
+        uses: c-hive/gha-remove-artifacts@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          age: '1 day'
+          skip-tags: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,119 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - v.*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: niden/actions-memcached@v7
+      - name: Restore Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: 1.14.x
+      - name: Run unit tests
+        run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
+      - name: Check codegen
+        run: make check-generated
+      - name: Build containers
+        run: make all
+  e2e-1:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - name: Restore Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: 1.14.x
+      - name: Build containers
+        run: make all
+      - name: Run tests
+        run: |
+          E2E_TESTS='10_* 11_* 12_*' make e2e-gh
+
+  e2e-2:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - name: Restore Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: 1.14.x
+      - name: Build containers
+        run: make all
+      - name: Run tests
+        run: E2E_TESTS='13_* 14_* 15_*' make e2e-gh
+  e2e-3:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - name: Restore Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: 1.14.x
+      - name: Build containers
+        run: make all
+      - name: Run tests
+        run: E2E_TESTS='16_* 17_*' make e2e-gh
+  e2e-4:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - name: Restore Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: 1.14.x
+      - name: Build containers
+        run: make all
+      - name: Run tests
+        run: E2E_TESTS='20_* 21_* 22_*' make e2e-gh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,16 +5,14 @@ on:
   push:
     branches:
       - master
-    tags-ignore:
-      - v.*
 
 jobs:
-  build:
+  unit-testing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: niden/actions-memcached@v7
-      - name: Restore Cache
+      - name: Restore Go cache
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
@@ -25,19 +23,31 @@ jobs:
         uses: actions/setup-go@v2-beta
         with:
           go-version: 1.14.x
-      - name: Run unit tests
+      - name: Run tests
         run: make test TEST_FLAGS="-race -tags integration -timeout 5m"
       - name: Check codegen
         run: make check-generated
-      - name: Build containers
+      - name: Build binaries
         run: make all
-  e2e-1:
+      - name: Prepare cache
+        run: |
+          cp "$(go env GOPATH)/bin/fluxctl" cache/fluxctl
+          docker save -o cache/flux-latest.tar fluxcd/flux:latest
+      - name: Upload cache
+        uses: actions/upload-artifact@v1
+        with:
+          name: cache
+          path: cache
+  e2e-testing:
     runs-on: ubuntu-latest
-    needs: build
+    needs: unit-testing
+    strategy:
+      matrix:
+        test: ['10_* 11_* 12_*', '13_* 14_*', '15_* 16_* 17_*', '20_* 21_* 22_*']
     steps:
       - uses: actions/checkout@v2
       - uses: engineerd/setup-kind@v0.3.0
-      - name: Restore Cache
+      - name: Restore Go cache
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
@@ -48,72 +58,16 @@ jobs:
         uses: actions/setup-go@v2-beta
         with:
           go-version: 1.14.x
-      - name: Build containers
-        run: make all
+      - name: Download cache
+        uses: actions/download-artifact@v1
+        with:
+          name: cache
+      - name: Load cache
+        run: |
+          chmod +x cache/fluxctl
+          sudo mv cache/fluxctl /usr/local/bin/fluxctl
+          docker load --input cache/flux-latest.tar -q
+          kind load docker-image fluxcd/flux:latest
       - name: Run tests
         run: |
-          E2E_TESTS='10_* 11_* 12_*' make e2e-gh
-
-  e2e-2:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
-      - name: Restore Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Setup Go
-        uses: actions/setup-go@v2-beta
-        with:
-          go-version: 1.14.x
-      - name: Build containers
-        run: make all
-      - name: Run tests
-        run: E2E_TESTS='13_* 14_* 15_*' make e2e-gh
-  e2e-3:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
-      - name: Restore Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Setup Go
-        uses: actions/setup-go@v2-beta
-        with:
-          go-version: 1.14.x
-      - name: Build containers
-        run: make all
-      - name: Run tests
-        run: E2E_TESTS='16_* 17_*' make e2e-gh
-  e2e-4:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
-      - name: Restore Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Setup Go
-        uses: actions/setup-go@v2-beta
-        with:
-          go-version: 1.14.x
-      - name: Build containers
-        run: make all
-      - name: Run tests
-        run: E2E_TESTS='20_* 21_* 22_*' make e2e-gh
+          E2E_TESTS='${{ matrix.test }}' make e2e-gh

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,13 @@
-on: [push, pull_request]
-name: Check links
+name: docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
-  linkChecker:
+  link-checker:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ test: test/bin/helm test/bin/kubectl test/bin/sops test/bin/kustomize $(GENERATE
 e2e: lint-e2e test/bin/helm test/bin/kubectl test/bin/sops test/bin/crane test/e2e/bats $(GOBIN)/fluxctl build/.flux.done
 	PATH="${PWD}/test/bin:${PATH}" CURRENT_OS_ARCH=$(CURRENT_OS_ARCH) test/e2e/run.bash
 
+e2e-gh: lint-e2e test/bin/helm test/bin/kubectl test/bin/sops test/bin/crane test/e2e/bats $(GOBIN)/fluxctl build/.flux.done
+	PATH="${PWD}/test/bin:${PATH}" CURRENT_OS_ARCH=$(CURRENT_OS_ARCH) test/e2e/run-gh.bash
+
 E2E_BATS_FILES := test/e2e/*.bats
 E2E_BASH_FILES := test/e2e/run.bash test/e2e/lib/*
 SHFMT_DIFF_CMD := test/bin/shfmt -i 2 -sr -d

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 GENERATED_TEMPLATES_FILE=pkg/install/generated_templates.gogen.go
 
-all: $(GOBIN)/fluxctl $(GOBIN)/fluxd build/.flux.done
+all: $(GOBIN)/fluxctl build/.flux.done
 
 release-bins: $(GENERATED_TEMPLATES_FILE)
 	for arch in amd64; do \
@@ -65,7 +65,7 @@ test: test/bin/helm test/bin/kubectl test/bin/sops test/bin/kustomize $(GENERATE
 e2e: lint-e2e test/bin/helm test/bin/kubectl test/bin/sops test/bin/crane test/e2e/bats $(GOBIN)/fluxctl build/.flux.done
 	PATH="${PWD}/test/bin:${PATH}" CURRENT_OS_ARCH=$(CURRENT_OS_ARCH) test/e2e/run.bash
 
-e2e-gh: lint-e2e test/bin/helm test/bin/kubectl test/bin/sops test/bin/crane test/e2e/bats $(GOBIN)/fluxctl build/.flux.done
+e2e-gh: lint-e2e test/bin/helm test/bin/kubectl test/bin/sops test/bin/crane test/e2e/bats
 	PATH="${PWD}/test/bin:${PATH}" CURRENT_OS_ARCH=$(CURRENT_OS_ARCH) test/e2e/run-gh.bash
 
 E2E_BATS_FILES := test/e2e/*.bats

--- a/test/e2e/fixtures/kustom/base/gitsrv/gitsrv.yaml
+++ b/test/e2e/fixtures/kustom/base/gitsrv/gitsrv.yaml
@@ -27,6 +27,16 @@ spec:
         - containerPort: 22
           name: ssh
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 22
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 22
+          initialDelaySeconds: 20
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /git-server/repos
           name: git-server-data

--- a/test/e2e/run-gh.bash
+++ b/test/e2e/run-gh.bash
@@ -16,16 +16,12 @@ KIND_CACHE_PATH="${CACHE_DIR}/kind-$KIND_VERSION"
 KIND_CLUSTER_PREFIX=flux-e2e
 BATS_EXTRA_ARGS=""
 
-sudo mv "$(go env GOPATH)/bin/fluxctl" "/usr/local/bin/fluxctl"
-
 # shellcheck disable=SC1090
 source "${E2E_DIR}/lib/defer.bash"
 trap run_deferred EXIT
 
 mkdir -p "${FLUX_ROOT_DIR}/cache"
 curl -sL "https://github.com/fluxcd/gitsrv/releases/download/${GITSRV_VERSION}/known_hosts.txt" > "${FLUX_ROOT_DIR}/cache/known_hosts"
-
-kind load docker-image 'docker.io/fluxcd/flux:latest'
 
 echo '>>> Running the tests'
 # Run all tests by default but let users specify which ones to run, e.g. with E2E_TESTS='11_*' make e2e

--- a/test/e2e/run-gh.bash
+++ b/test/e2e/run-gh.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# This script runs the bats tests
+
+# Directory paths we need to be aware of
+FLUX_ROOT_DIR="$(git rev-parse --show-toplevel)"
+E2E_DIR="${FLUX_ROOT_DIR}/test/e2e"
+CACHE_DIR="${FLUX_ROOT_DIR}/cache/$CURRENT_OS_ARCH"
+
+KIND_VERSION=v0.7.0
+KUBE_VERSION=v1.14.10
+GITSRV_VERSION=v1.0.0
+KIND_CACHE_PATH="${CACHE_DIR}/kind-$KIND_VERSION"
+KIND_CLUSTER_PREFIX=flux-e2e
+BATS_EXTRA_ARGS=""
+
+sudo mv "$(go env GOPATH)/bin/fluxctl" "/usr/local/bin/fluxctl"
+
+# shellcheck disable=SC1090
+source "${E2E_DIR}/lib/defer.bash"
+trap run_deferred EXIT
+
+mkdir -p "${FLUX_ROOT_DIR}/cache"
+curl -sL "https://github.com/fluxcd/gitsrv/releases/download/${GITSRV_VERSION}/known_hosts.txt" > "${FLUX_ROOT_DIR}/cache/known_hosts"
+
+kind load docker-image 'docker.io/fluxcd/flux:latest'
+
+echo '>>> Running the tests'
+# Run all tests by default but let users specify which ones to run, e.g. with E2E_TESTS='11_*' make e2e
+E2E_TESTS=${E2E_TESTS:-.}
+(
+  cd "${E2E_DIR}"
+  # shellcheck disable=SC2086
+  "${E2E_DIR}/bats/bin/bats" -t ${BATS_EXTRA_ARGS} ${E2E_TESTS}
+)


### PR DESCRIPTION
GitHub Actions migration (ref: #2944):
- [x] run unit tests
- [x] verify codegen
- [x] build binaries and containers
- [x] run e2e tests (four Kubernetes Kind clusters matrix)

GH Actions specific changes:
- cache go modules
- run one Kubernetes cluster per VM
- upload fluxd container image, fluxctl, kubectl, kustomize and sops to GH artifacts 
- download the artifacts in e2e jobs to avoid rebuilding binaries and containers
- cleanup artifacts daily 

Conclusions:
- the random kind/docker/kubeadm failures that we experienced with CircleCI are gone
- no more `sudo killall apt-get`, apt-get doesn't hang  like in CircleCI
- the e2e tests take the same amount of time on GH Actions free as in CircleCI paid account
- the major downside to GH Actions is the lack of docker image caching between jobs
- you have to use docker save/load and upload/download artifacts between jobs
- you can't delete artifacts during a GH workflow run 
- GH Actions UI is unreliable and buggy, most of the time the logs are not displayed until the job finishes 

Overall I'm happy with GitHub Actions even though it was a painful migration.