### PR TITLE
ci: more thorough link checking

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,6 +14,19 @@ jobs:
         python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
+      # Using markdown-link-check to check markdown docs
+      - name: Link Checker (for top-level markdown docs)
+        uses: dholbach/github-action-markdown-link-check@add-max-depth
+        with:
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdown-link-check-config.json'
+          folder-path: ./
+          max-depth: 1
+      - name: Link Checker (for ./internal markdown docs)
+        uses: dholbach/github-action-markdown-link-check@add-max-depth
+        with:
+          use-verbose-mode: 'yes'
+          folder-path: ./internal/docs/
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -24,10 +37,11 @@ jobs:
           pip install -r docs/requirements.txt
       - name: Build docs for link check
         run: mkdocs build
-      - name: Link Checker
+      # Using liche action to check generated HTML site
+      - name: Link Checker (generated site)
         id: lc
         uses: peter-evans/link-checker@v1
         with:
-          args: -r -d site/ -v site/index.html
+          args: -v -d ./site -r ./site
       - name: Fail if there were link errors
         run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,0 +1,9 @@
+{
+    "ignorePatterns": [
+        {
+            "githubIssuePattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+",
+            "mailtoPattern": "^mailto:",
+            "companySitesWith403sPattern": "^https://www.(blablacar|canva|underarmour).com"
+        }
+    ]
+}


### PR DESCRIPTION
I split this out of #2948. So this PR can be about link checking only.

- .github/workflows/markdown-link-check-config.json has some patterns we exclude while checking the markdown files in the top-level directories (company websites on README.md and billions of GH issues in CHANGELOG.md in particular)
- once gaurav-nelson/github-action-markdown-link-check#26 is merged, we can move back to the official GH Action

Overall it gets more complicated. What I'm doing here is:
- check generated docs in `site` using the action which uses `liche` - this works as well as it did before
- use the new markdown action to check the docs in `./` and `./internal/docs` - unfortunately you can't pass two paths easily and I needed to mess with the `find` incantation in the action itself, thanks @hiddeco for the psychological support.
