### PR TITLE
Make docker/image-tag work on MacOS again

### DIFF
--- a/docker/image-tag
+++ b/docker/image-tag
@@ -27,7 +27,7 @@ case ${#HEAD_TAGS[@]} in
        if [[ "${TAG2}" == v* && ${TAG2%$TAG1} == "v" ]]; then
            echo ${TAG1}; exit 0
        fi
-       ;&
+       echo "error: more than one tag pointing to HEAD" >&2; exit 1; ;;
 
     *) echo "error: more than one tag pointing to HEAD" >&2; exit 1; ;;
 esac


### PR DESCRIPTION
The sigil `;&` is a Bash v4-ism, and MacOS ships only with Bash
3.2. To get it working, I just duplicated the line that would be run
by the `;&` fallthrough.
