### PR TITLE
Update get started docs

### DIFF
--- a/docs/tutorials/get-started-helm.md
+++ b/docs/tutorials/get-started-helm.md
@@ -19,7 +19,7 @@ Download Helm v3:
 - On MacOS:
 
   ```sh
-  brew install kubernetes-helm
+  brew install helm
   ```
 
 - On Linux:

--- a/docs/tutorials/get-started.md
+++ b/docs/tutorials/get-started.md
@@ -96,7 +96,7 @@ change its configuration to use a different message.
 Replace `YOURUSER` in
 `https://github.com/YOURUSER/flux-get-started/blob/master/workloads/podinfo-dep.yaml`
 with your GitHub ID), open the URL in your browser, edit the file,
-change the `PODINFO_UI_MESSAGE` env var to `Welcome to Flux` and commit the file.
+add `--ui-message='Welcome to Flux'` to the container command and commit the file.
 
 By default, Flux git pull frequency is set to 5 minutes.
 You can tell Flux to sync the changes immediately with:


### PR DESCRIPTION
- update fluxctl commands to match the get started repo
- remove deprecated Helm install commands

Fix: https://github.com/fluxcd/flux-get-started/issues/34