### PR TITLE
build: move back to upstream gh action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,14 +16,14 @@ jobs:
       - uses: actions/checkout@v2
       # Using markdown-link-check to check markdown docs
       - name: Link Checker (for top-level markdown docs)
-        uses: dholbach/github-action-markdown-link-check@add-max-depth
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'yes'
           config-file: '.github/workflows/markdown-link-check-config.json'
           folder-path: ./
           max-depth: 1
       - name: Link Checker (for ./internal markdown docs)
-        uses: dholbach/github-action-markdown-link-check@add-max-depth
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'yes'
           folder-path: ./internal/docs/


### PR DESCRIPTION
[My fix](https://github.com/gaurav-nelson/github-action-markdown-link-check/pull/26) for the GH Action we use to check markdown files has been merged, so let's move back to the upstream action.