### PR TITLE
Set `/dockercfg/` path for custom dockerconfig files

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -268,7 +268,7 @@ spec:
           - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId }}
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
-          - --docker-config={{ .Values.registry.dockercfg.configFileName }}
+          - --docker-config=/dockercfg/{{ .Values.registry.dockercfg.configFileName }}
           {{- end }}
           {{- if .Values.token }}
           - --connect=wss://cloud.weave.works/api/flux


### PR DESCRIPTION
The chart mounts the dockercfg.secretName in the `/dockercfg/`, but the path is not setted for the `configFileName`, so it does not takes the right configuration when using it. Otherwise the `configFileName` needs to be setted with the full path `/dockercfg/dockerconfigfile.json`