### PR TITLE
Fix missing return on ECR domain check

### DIFF
--- a/pkg/registry/aws.go
+++ b/pkg/registry/aws.go
@@ -57,6 +57,7 @@ func contains(strs []string, str string) bool {
 func validECRHost(domain string) bool {
 	switch {
 	case strings.HasSuffix(domain, awsPartitionSuffix):
+		return true
 	case strings.HasSuffix(domain, awsCnPartitionSuffix):
 		return true
 	}


### PR DESCRIPTION
Simple bug introduced in #2982 