### PR TITLE
Whitelist 3 env vars for Git cmd executions

### DIFF
--- a/pkg/git/operations.go
+++ b/pkg/git/operations.go
@@ -37,6 +37,10 @@ var allowedEnvVars = []string{
 	// these are for Google Cloud SDK to find its files (which will
 	// have to be mounted, if running in a container)
 	"CLOUDSDK_CONFIG", "CLOUDSDK_PYTHON",
+	// those vars are for NSS_WRAPPER, which is used to solve ssh error - "No user exists for uid xxxxxxxxxx",
+	// when container is running in hardened Openshift environments and user id is not found in /etc/passwd
+	// for usage flux must be wrapped using https://cwrap.org/nss_wrapper.html library
+	"NSS_WRAPPER_PASSWD", "NSS_WRAPPER_GROUP", "LD_PRELOAD",
 }
 
 type gitCmdConfig struct {


### PR DESCRIPTION
* "NSS_WRAPPER_PASSWD"
* "NSS_WRAPPER_GROUP"
* "LD_PRELOAD"

it is required, when:
* fluxcd is running in the K8s or openshift clusters, where user id is higher you can specify in Dockerfile
* fluxcd is used in conjunction with NSS_WRAPPER, where wrapper adds user id into /etc/passwd and /etc/groups alternate files
* gitops repository is cloned only via SSH protocol

This can be useful for the guys, who are trying to run gitops in hardened Openshift clusters, where they cannot grant any privileges to flux container and cannot use HTTPS transport for cloning git repositories