### PR TITLE
Update chart git.path docs

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -214,7 +214,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.url`                                         | `None`                                               | URL of git repo with Kubernetes manifests
 | `git.readonly`                                    | `false`                                              | If `true`, the git repo will be considered read-only, Flux will not attempt to write to it
 | `git.branch`                                      | `master`                                             | Branch of git repo to use for Kubernetes manifests
-| `git.path`                                        | `None`                                               | Path within git repo to locate Kubernetes manifests (relative path)
+| `git.path`                                        | `None`                                               | One or more paths within git repo to locate Kubernetes manifests (relative path(s))
 | `git.user`                                        | `Weave Flux`                                         | Username to use as git committer
 | `git.email`                                       | `support@weave.works`                                | Email to use as git committer
 | `git.setAuthor`                                   | `false`                                              | If set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer.


### PR DESCRIPTION
As seen in the `git-path` [flag source code](https://github.com/fluxcd/flux/blob/8b4c115fd211089e2f8718b43c7a11e8efc7ceb0/cmd/fluxctl/install_cmd.go#L37), it can take more than one string values (in the form `git-path=path1,path2,...,pathN`)
This PR enhances the `git.path` documentation in the Helm chart README file, so that it is explicitly mentioned that more than one git paths can be defined.