### PR TITLE
Expand the GCP credentials support to GAR ( `*-docker.pkg.dev` )

### DIFF
--- a/pkg/registry/credentials.go
+++ b/pkg/registry/credentials.go
@@ -140,7 +140,7 @@ func (cs Credentials) credsFor(host string) creds {
 	if cred, found := cs.m[host]; found {
 		return cred
 	}
-	if host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") {
+	if host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") || strings.HasSuffix(host, "-docker.pkg.dev") {
 		if cred, err := GetGCPOauthToken(host); err == nil {
 			return cred
 		}


### PR DESCRIPTION
Hello,

A new registry (GAR) is available on GCP. Like GCR, credential are not mandatory. The cluster's one can be use instead. 
Currently flux do not pick that. I simply add the gar endpoint in the list.
