### PR TITLE
direct comparison of last-synced and newly-synced resources

### DIFF
--- a/pkg/cluster/kubernetes/testfiles/data.go
+++ b/pkg/cluster/kubernetes/testfiles/data.go
@@ -395,6 +395,24 @@ metadata:
 `,
 }
 
+var FilesMultidoc = map[string]string{
+	"namespaces.yaml": `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+  annotations:
+    key: value
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+  annotations:
+    key: value
+`,
+}
+
 var SopsEncryptedFiles = map[string]string{
   "garbage": "This should just be ignored, since it is not YAML",
   "helloworld-deploy.yaml": `apiVersion: ENC[AES256_GCM,data:N/68Js00AtWIvks/pt+be5AW,iv:9Ke36D3faRNrMzm82Z9ETl3lOMhhWy8fh907K5e2Ar4=,tag:EfAzs1AQvLRH/tIQ+iZttw==,type:str]

--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -130,10 +130,7 @@ func (d *Daemon) getLastResources(ctx context.Context, rat ratchet) (map[string]
 		return make(map[string]resource.Resource), nil
 	}
 
-	// First sync
-	d.Logger.Log("info", "resource map is not initialized, despite repo has been cloned")
-
-	// Load resources from clone of currentRevision
+	// Fist sync -- load resources from clone of currentRevision
 	lastResourcestore, cleanup, err := d.getManifestStoreByRevision(ctx, currentRevision)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading the repository checkout")

--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -1,15 +1,16 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"time"
+
 	"github.com/fluxcd/flux/pkg/metrics"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
-	"path/filepath"
-	"time"
 
 	"github.com/fluxcd/flux/pkg/cluster"
 	"github.com/fluxcd/flux/pkg/event"
@@ -20,13 +21,15 @@ import (
 	"github.com/fluxcd/flux/pkg/update"
 )
 
-// revisionRatchet is for keeping track of transitions between
+// ratchet is for keeping track of transitions between
 // revisions. This is slightly more complicated than just setting the
 // state, since we want to notice unexpected transitions (e.g., when
 // the apparent current state is not what we'd recorded).
-type revisionRatchet interface {
-	Current(ctx context.Context) (string, error)
-	Update(ctx context.Context, oldRev, newRev string) (bool, error)
+type ratchet interface {
+	CurrentRevision(ctx context.Context) (string, error)
+	CurrentResources() map[string]resource.Resource
+
+	Update(ctx context.Context, oldRev, newRev string, resources map[string]resource.Resource) (bool, error)
 }
 
 type eventLogger interface {
@@ -41,67 +44,52 @@ type changeSet struct {
 }
 
 // Sync starts the synchronization of the cluster with git.
-func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, ratchet revisionRatchet) error {
-	// Make a read-only clone used for this sync
-	ctxt, cancel := context.WithTimeout(ctx, d.GitTimeout)
-	working, err := d.Repo.Export(ctxt, newRevision)
+func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, rat ratchet) error {
+	// Load last-synced resources for comparison
+	lastResources, err := d.getLastResources(ctx, rat)
 	if err != nil {
-		return err
-	}
-	cancel()
-	defer func() {
-		if err := working.Clean(); err != nil {
-			d.Logger.Log("error", fmt.Sprintf("cannot clean sync clone: %s", err))
-		}
-	}()
-
-	// Unseal any secrets if enabled
-	if d.GitSecretEnabled {
-		ctxt, cancel := context.WithTimeout(ctx, d.GitTimeout)
-		if err := working.SecretUnseal(ctxt); err != nil {
-			return err
-		}
-		cancel()
+		return errors.Wrap(err, "loading last-synced resources")
 	}
 
 	// Retrieve change set of commits we need to sync
-	c, err := d.getChangeSet(ctx, ratchet, newRevision)
+	changeSet, err := d.getChangeSet(ctx, rat, newRevision)
 	if err != nil {
 		return err
 	}
 
-	d.Logger.Log("info", "trying to sync git changes to the cluster", "old", c.oldTagRev, "new", c.newTagRev)
+	d.Logger.Log("info", "trying to sync git changes to the cluster", "old", changeSet.oldTagRev, "new", changeSet.newTagRev)
+
+	// Load resources from the new revision
+	resourceStore, cleanup, err := d.getManifestStoreByRevision(ctx, newRevision)
+	if err != nil {
+		return errors.Wrap(err, "loading new resources")
+	}
+	defer cleanup()
 
 	// Run actual sync of resources on cluster
 	syncSetName := makeGitConfigHash(d.Repo.Origin(), d.GitConfig)
-	resourceStore, err := d.getManifestStore(working)
-	if err != nil {
-		return errors.Wrap(err, "reading the repository checkout")
-	}
 	resources, resourceErrors, err := doSync(ctx, resourceStore, d.Cluster, syncSetName, d.Logger)
 	if err != nil {
 		return err
 	}
 
-	// Determine what resources changed during the sync
-	changedResources, err := d.getChangedResources(ctx, c, d.GitTimeout, working, resourceStore, resources)
-	serviceIDs := resource.IDSet{}
-	for _, r := range changedResources {
-		serviceIDs.Add([]resource.ID{r.ResourceID()})
-	}
+	// Determine what resources changed and deleted during the sync
+	updatedIDs, deletedIDs := compareResources(lastResources, resources)
+	// TODO(ordovicia): include deleted resources in sync events
+	_ = deletedIDs
 
 	// Retrieve git notes and collect events from them
 	notes, err := d.getNotes(ctx, d.GitTimeout)
 	if err != nil {
 		return err
 	}
-	noteEvents, includesEvents, err := d.collectNoteEvents(ctx, c, notes, d.GitTimeout, started, d.Logger)
+	noteEvents, includesEvents, err := d.collectNoteEvents(ctx, changeSet, notes, d.GitTimeout, started, d.Logger)
 	if err != nil {
 		return err
 	}
 
 	// Report all synced commits
-	if err := logCommitEvent(d, c, serviceIDs, started, includesEvents, resourceErrors, d.Logger); err != nil {
+	if err := logCommitEvent(d, changeSet, updatedIDs, started, includesEvents, resourceErrors, d.Logger); err != nil {
 		return err
 	}
 
@@ -115,7 +103,7 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	}
 
 	// Move the revision the sync state points to
-	if ok, err := ratchet.Update(ctx, c.oldTagRev, c.newTagRev); err != nil {
+	if ok, err := rat.Update(ctx, changeSet.oldTagRev, changeSet.newTagRev, resources); err != nil {
 		return err
 	} else if !ok {
 		return nil
@@ -125,13 +113,86 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	return err
 }
 
+// getLastResources loads last-synced resources
+func (d *Daemon) getLastResources(ctx context.Context, rat ratchet) (map[string]resource.Resource, error) {
+	lastResources := rat.CurrentResources()
+	if lastResources != nil {
+		return lastResources, nil
+	}
+
+	currentRevision, err := rat.CurrentRevision(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Repo has never been cloned yet
+	if currentRevision == "" {
+		return make(map[string]resource.Resource), nil
+	}
+
+	// First sync
+	d.Logger.Log("info", "resource map is not initialized, despite repo has been cloned")
+
+	// Load resources from clone of currentRevision
+	lastResourcestore, cleanup, err := d.getManifestStoreByRevision(ctx, currentRevision)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading the repository checkout")
+	}
+	defer cleanup()
+
+	lastResources, err = lastResourcestore.GetAllResourcesByID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading resources from repo")
+	}
+
+	return lastResources, nil
+}
+
+// getManifestStoreByRevision loads manifests from a clone of a given revision.
+func (d *Daemon) getManifestStoreByRevision(ctx context.Context, revision string) (store manifests.Store, cleanupClone func(), err error) {
+	clone, cleanupClone, err := d.cloneRepo(ctx, revision)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "cloning repo")
+	}
+
+	store, err = d.getManifestStore(clone)
+	return store, cleanupClone, err
+}
+
+// cloneRepo makes a read-only clone of the given revision
+func (d *Daemon) cloneRepo(ctx context.Context, revision string) (clone *git.Export, cleanup func(), err error) {
+	ctxGitOp, cancel := context.WithTimeout(ctx, d.GitTimeout)
+	defer cancel()
+	clone, err = d.Repo.Export(ctxGitOp, revision)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Unseal any secrets if enabled
+	if d.GitSecretEnabled {
+		ctxGitOp, cancel := context.WithTimeout(ctx, d.GitTimeout)
+		defer cancel()
+		if err := clone.SecretUnseal(ctxGitOp); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	cleanup = func() {
+		if err := clone.Clean(); err != nil {
+			d.Logger.Log("error", fmt.Sprintf("cannot clean clone: %s", err))
+		}
+	}
+
+	return clone, cleanup, nil
+}
+
 // getChangeSet returns the change set of commits for this sync,
 // including the revision range and if it is an initial sync.
-func (d *Daemon) getChangeSet(ctx context.Context, state revisionRatchet, headRev string) (changeSet, error) {
+func (d *Daemon) getChangeSet(ctxGitOp context.Context, state ratchet, headRev string) (changeSet, error) {
 	var c changeSet
 	var err error
 
-	currentRev, err := state.Current(ctx)
+	currentRev, err := state.CurrentRevision(ctxGitOp)
 	if err != nil {
 		return c, err
 	}
@@ -144,12 +205,12 @@ func (d *Daemon) getChangeSet(ctx context.Context, state revisionRatchet, headRe
 		paths = []string{}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, d.GitTimeout)
+	ctxGitOp, cancel := context.WithTimeout(ctxGitOp, d.GitTimeout)
 	if c.oldTagRev != "" {
-		c.commits, err = d.Repo.CommitsBetween(ctx, c.oldTagRev, c.newTagRev, false, paths...)
+		c.commits, err = d.Repo.CommitsBetween(ctxGitOp, c.oldTagRev, c.newTagRev, false, paths...)
 	} else {
 		c.initialSync = true
-		c.commits, err = d.Repo.CommitsBefore(ctx, c.newTagRev, false, paths...)
+		c.commits, err = d.Repo.CommitsBefore(ctxGitOp, c.newTagRev, false, paths...)
 	}
 	cancel()
 
@@ -192,58 +253,33 @@ func updateSyncManifestsMetric(success, failure int) {
 	syncManifestsMetric.With(metrics.LabelSuccess, "false").Set(float64(failure))
 }
 
-// getChangedResources calculates what resources are modified during
-// this sync.
-func (d *Daemon) getChangedResources(ctx context.Context, c changeSet, timeout time.Duration, working *git.Export,
-	manifestsStore manifests.Store, resources map[string]resource.Resource) (map[string]resource.Resource, error) {
-	if c.initialSync {
-		return resources, nil
+func compareResources(old, new map[string]resource.Resource) (updated, deleted resource.IDSet) {
+	updated, deleted = resource.IDSet{}, resource.IDSet{}
+	toIDs := func(r resource.Resource) []resource.ID { return []resource.ID{r.ResourceID()} }
+
+	for newID, newResource := range new {
+		if oldResource, ok := old[newID]; ok {
+			if !bytes.Equal(oldResource.Bytes(), newResource.Bytes()) {
+				updated.Add(toIDs(newResource))
+			}
+		} else {
+			updated.Add(toIDs(newResource))
+		}
 	}
 
-	errorf := func(err error) error { return errors.Wrap(err, "loading resources from repo") }
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	changedFiles, err := working.ChangedFiles(ctx, c.oldTagRev, d.GitConfig.Paths)
-	if err != nil {
-		return nil, errorf(err)
-	}
-	cancel()
-	// Get the resources by source
-	resourcesByID, err := manifestsStore.GetAllResourcesByID(ctx)
-	if err != nil {
-		return nil, errorf(err)
-	}
-	resourcesBySource := make(map[string]resource.Resource, len(resourcesByID))
-	for _, r := range resourcesByID {
-		resourcesBySource[r.Source()] = r
+	for oldID, oldResource := range old {
+		if _, ok := new[oldID]; !ok {
+			deleted.Add(toIDs(oldResource))
+		}
 	}
 
-	changedResources := map[string]resource.Resource{}
-	// FIXME(michael): this won't be accurate when a file can have more than one resource
-	for _, absolutePath := range changedFiles {
-		relPath, err := filepath.Rel(working.Dir(), absolutePath)
-		if err != nil {
-			return nil, errorf(err)
-		}
-		if r, ok := resourcesBySource[relPath]; ok {
-			changedResources[r.ResourceID().String()] = r
-		}
-	}
-	// All resources generated from .flux.yaml files need to be considered as changed
-	// (even if the .flux.yaml file itself didn't) since external dependencies of the file
-	// (e.g. scripts invoked), which we cannot track, may have changed
-	for sourcePath, r := range resourcesBySource {
-		_, sourceFilename := filepath.Split(sourcePath)
-		if sourceFilename == manifests.ConfigFilename {
-			changedResources[r.ResourceID().String()] = r
-		}
-	}
-	return changedResources, nil
+	return updated, deleted
 }
 
 // getNotes retrieves the git notes from the working clone.
 func (d *Daemon) getNotes(ctx context.Context, timeout time.Duration) (map[string]struct{}, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	notes, err := d.Repo.NoteRevList(ctx, d.GitConfig.NotesRef)
+	ctxGitOp, cancel := context.WithTimeout(ctx, timeout)
+	notes, err := d.Repo.NoteRevList(ctxGitOp, d.GitConfig.NotesRef)
 	cancel()
 	if err != nil {
 		return nil, errors.Wrap(err, "loading notes from repo")
@@ -272,8 +308,8 @@ func (d *Daemon) collectNoteEvents(ctx context.Context, c changeSet, notes map[s
 			continue
 		}
 		var n note
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		ok, err := d.Repo.GetNote(ctx, c.commits[i].Revision, d.GitConfig.NotesRef, &n)
+		ctxGitOp, cancel := context.WithTimeout(ctx, timeout)
+		ok, err := d.Repo.GetNote(ctxGitOp, c.commits[i].Revision, d.GitConfig.NotesRef, &n)
 		cancel()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "loading notes from repo")
@@ -406,8 +442,8 @@ func logCommitEvent(el eventLogger, c changeSet, serviceIDs resource.IDSet, star
 // refresh refreshes the repository, notifying the daemon we have a new
 // sync head.
 func refresh(ctx context.Context, timeout time.Duration, repo *git.Repo) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	err := repo.Refresh(ctx)
+	ctxGitOp, cancel := context.WithTimeout(ctx, timeout)
+	err := repo.Refresh(ctxGitOp)
 	cancel()
 	return err
 }

--- a/pkg/daemon/sync_test.go
+++ b/pkg/daemon/sync_test.go
@@ -522,6 +522,144 @@ func TestDoSync_WithKustomize(t *testing.T) {
 	}
 }
 
+func TestDoSync_WithMultidoc(t *testing.T) {
+	d, cleanup := daemon(t, testfiles.FilesMultidoc)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	var syncTag = "syncy-mcsyncface"
+	// Set the sync tag to head
+	var oldRevision, newRevision string
+	err := d.WithWorkingClone(ctx, func(checkout *git.Checkout) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		var err error
+		tagAction := git.TagAction{
+			Tag:      syncTag,
+			Revision: "master",
+			Message:  "Sync pointer",
+		}
+		err = checkout.MoveTagAndPush(ctx, tagAction)
+		if err != nil {
+			return err
+		}
+		oldRevision, err = checkout.HeadRevision(ctx)
+		if err != nil {
+			return err
+		}
+		// Push some new changes
+		cm := manifests.NewRawFiles(checkout.Dir(), checkout.AbsolutePaths(), d.Manifests)
+		resourcesByID, err := cm.GetAllResourcesByID(context.TODO())
+		if err != nil {
+			return err
+		}
+		targetResource := "default:namespace/foo"
+		res, ok := resourcesByID[targetResource]
+		if !ok {
+			return fmt.Errorf("resource not found: %q", targetResource)
+
+		}
+		absolutePath := path.Join(checkout.Dir(), res.Source())
+		def, err := ioutil.ReadFile(absolutePath)
+		if err != nil {
+			return err
+		}
+		newDef := bytes.Replace(def, []byte("key: value"), []byte("key: value2"), -1)
+		if err := ioutil.WriteFile(absolutePath, newDef, 0600); err != nil {
+			return err
+		}
+
+		commitAction := git.CommitAction{Author: "", Message: "test commit"}
+		err = checkout.CommitAndPush(ctx, commitAction, nil, false)
+		if err != nil {
+			return err
+		}
+		newRevision, err = checkout.HeadRevision(ctx)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.Repo.Refresh(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	syncCalled := 0
+	var syncDef *cluster.SyncSet
+	expectedResourceIDs := resource.IDs{}
+	for id := range testfiles.ResourceMap {
+		expectedResourceIDs = append(expectedResourceIDs, id)
+	}
+	expectedResourceIDs.Sort()
+	k8s.SyncFunc = func(def cluster.SyncSet) error {
+		syncCalled++
+		syncDef = &def
+		return nil
+	}
+
+	head, err := d.Repo.BranchHead(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", fluxsync.VerifySignaturesModeNone, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	if err := d.Sync(ctx, time.Now().UTC(), head, syncState); err != nil {
+		t.Error(err)
+	}
+
+	// It applies everything
+	if syncCalled != 1 {
+		t.Errorf("Sync was not called once, was called %d times", syncCalled)
+	} else if syncDef == nil {
+		t.Errorf("Sync was called with a nil syncDef")
+	}
+
+    // A sync event is emitted and it only has updated workload ids
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
+	if err != nil {
+		t.Error(err)
+	} else if len(es) != 1 {
+		t.Errorf("Unexpected events: %#v", es)
+	} else if es[0].Type != event.EventSync {
+		t.Errorf("Unexpected event type: %#v", es[0])
+	} else {
+		gotResourceIDs := es[0].ServiceIDs
+		resource.IDs(gotResourceIDs).Sort()
+
+		expected0 := []resource.ID{
+			resource.MustParseID("default:namespace/foo"),
+			resource.MustParseID("default:namespace/bar"),
+		}
+		expected1 := []resource.ID{
+			resource.MustParseID("default:namespace/bar"),
+			resource.MustParseID("default:namespace/foo"),
+		}
+
+		// Event should only have changed workload ids
+		if !(reflect.DeepEqual(gotResourceIDs, expected0) || reflect.DeepEqual(gotResourceIDs, expected1)) {
+			t.Errorf("Unexpected event workload ids: %#v, expected: %#v", gotResourceIDs, expected0)
+		}
+	}
+	// It moves the tag
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := d.Repo.Refresh(ctx); err != nil {
+		t.Errorf("pulling sync tag: %v", err)
+	} else if revs, err := d.Repo.CommitsBetween(ctx, oldRevision, syncTag, false); err != nil {
+		t.Errorf("finding revisions before sync tag: %v", err)
+	} else if len(revs) <= 0 {
+		t.Errorf("Should have moved sync tag forward")
+	} else if revs[len(revs)-1].Revision != newRevision {
+		t.Errorf("Should have moved sync tag to HEAD (%s), but was moved to: %s", newRevision, revs[len(revs)-1].Revision)
+	}
+}
+
 func TestDoSync_WithErrors(t *testing.T) {
 	d, cleanup := daemon(t, testfiles.Files)
 	defer cleanup()


### PR DESCRIPTION
`getChangedResources()` in `pkg/daemon/sync.go` could not determine what
resources are modified when a manifest file has multiple resource
definitions. This commit replaces `getChangedResources()` with new
`compareResources()` function, which determines resource updates and
deletions by direct comparison of last-synced and newly-synced clones.

Fixes #2494
Fixes #2981

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
