### PR TITLE
[chart] Add upstreamService variable

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -244,6 +244,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `dnsPolicy`                                       | ``                                                   | Pod DNS policy
 | `dnsConfig`                                       | ``                                                   | Pod DNS config
 | `token`                                           | `None`                                               | Weave Cloud service token
+| `upstreamService`                                 | `None`                                               | An upstream service address. If token is not empty, upstreamService=wss://cloud.weave.works/api/flux
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
 | `extraEnvsFrom`                                   | `[]`                                                 | Extra environment variables from a list of sources for the Flux pod(s)
 | `env.secretName`                                  | ``                                                   | Name of the secret that contains environment variables which should be defined in the Flux container (using `envFrom`)

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -290,6 +290,9 @@ spec:
           - --connect=wss://cloud.weave.works/api/flux
           - --token={{ .Values.token }}
           {{- end }}
+          {{- if .Values.upstreamService }}
+          - --connect={{ .Values.upstreamService }}
+          {{- end }}
           {{- if and .Values.syncGarbageCollection.enabled (not .Values.syncGarbageCollection.dry) }}
           - --sync-garbage-collection={{ .Values.syncGarbageCollection.enabled }}
           {{- else if .Values.syncGarbageCollection.dry }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -2,6 +2,7 @@
 
 # Weave Cloud service token
 token: ""
+upstreamService: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
In order to keep backward compatibility `--connect=wss://cloud.weave.works/api/flux` is left hardcoded if `.Values.token!=""`