### PR TITLE
Support annotations in chart SSH secret

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -234,6 +234,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `gpgKeys.configMapName`                           | `None`                                               | Kubernetes config map with public GPG keys the Flux daemon should import
 | `sops.enabled`                                    | `false`                                              | If `true` SOPS support will be enabled
 | `ssh.known_hosts`                                 | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
+| `ssh.secret.annotations`                          | `{}`                                                 | Additional secret annotations
 | `registry.automationInterval`                     | `5m`                                                 | Period at which to check for updated images
 | `registry.rps`                                    | `200`                                                | Maximum registry requests per second per host
 | `registry.burst`                                  | `125`                                                | Maximum number of warmer connections to remote and memcache

--- a/chart/flux/templates/secret.yaml
+++ b/chart/flux/templates/secret.yaml
@@ -3,5 +3,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flux.fullname" . }}-git-deploy
+  {{- if .Values.ssh.secret.annotations }}
+  annotations: {{ toYaml .Values.ssh.secret.annotations | nindent 4 }}
+  {{- end }}
 type: Opaque
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -226,6 +226,9 @@ ssh:
     # “PKCS8” (PEM PKCS8 public key) or
     # “PEM” (PEM public key).
     format: "RFC4716"
+  secret:
+    # Annotations for the Secret
+    annotations: {}
 
 kube:
   # Override for kubectl default config


### PR DESCRIPTION
We're using Spinnaker to deploy `flux`.

By default, Spinnaker version `secrets` and `configmap` unless they are annotated. See `strategy.spinnaker.io/versioned` at https://www.spinnaker.io/reference/providers/kubernetes-v2/#strategy

This PR allows to add annotations to the secret so you can disable Spinnaker versioning.

~Created as draft while testing.~ Tested and deployed successfully. 