### PR TITLE
docs: update helm operator integration glob patterns

### DIFF
--- a/docs/references/helm-operator-integration.md
+++ b/docs/references/helm-operator-integration.md
@@ -96,7 +96,9 @@ is required for any of these to take effect.
 | **`repository.fluxcd.io/<alias>`** | `sub.repo`       |     ✅    |
 | `registry.fluxcd.io/<alias>`       | `sub.reg`        |           |
 | `tag.fluxcd.io/<alias>`            | `sub.tag`        |           |
-| `filter.fluxcd.io/<alias>`         | `glob: master-*` |           |
+| `filter.fluxcd.io/<alias>`         | `glob:master-*` |           |
+
+> Note: Glob patterns following `glob:` are sensitive to spaces
 
 The following example `HelmRelease` specifies two images:
 
@@ -106,7 +108,7 @@ metadata:
     # image and tag
     repository.fluxcd.io/app: appImage
     tag.fluxcd.io/app: appTag
-    filter.fluxcd.io/app: 'glob: *'
+    filter.fluxcd.io/app: 'glob:*'
     # nested image with registry and tag
     registry.fluxcd.io/submarine: sub.marinesystem.reg
     repository.fluxcd.io/submarine: sub.marinesystem.img


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [x] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->

Address #3041 

Seems to be an error in the `references/helm-operator-integration` docs about having spaces in following the `glob:` key. I propose just updating the docs instead of trimming the whitespace since a space is technically valid regex and could potentially break someone if stripped.