### PR TITLE
Preserve namesace when running helm template

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}

--- a/chart/flux/templates/gitconfig.yaml
+++ b/chart/flux/templates/gitconfig.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "git.config.secretName" . }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   gitconfig: {{ .Values.git.config.data | b64enc }}

--- a/chart/flux/templates/kube.yaml
+++ b/chart/flux/templates/kube.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "flux.fullname" . }}-kube-config
+  namespace: {{ .Release.Namespace }}
 data:
   config: |
     {{- if not .Values.clusterRole.create }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flux.fullname" . }}-memcached
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "flux.name" . }}-memcached
     chart: {{ template "flux.chart" . }}

--- a/chart/flux/templates/psp.yaml
+++ b/chart/flux/templates/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "flux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "flux.name" . }}
     chart: {{ include "flux.chart" . }}

--- a/chart/flux/templates/secret.yaml
+++ b/chart/flux/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flux.fullname" . }}-git-deploy
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.ssh.secret.annotations }}
   annotations: {{ toYaml .Values.ssh.secret.annotations | nindent 4 }}
   {{- end }}

--- a/chart/flux/templates/service.yaml
+++ b/chart/flux/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "flux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}

--- a/chart/flux/templates/serviceaccount.yaml
+++ b/chart/flux/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "flux.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}

--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "flux.fullname" . }}-ssh-config
+  namespace: {{ .Release.Namespace }}
 data:
   known_hosts: |
     {{- if .Values.ssh.known_hosts }}


### PR DESCRIPTION
Helm chart now preserves target namespace when running 'helm template'
For motivation, please read this thread: https://github.com/bitnami/charts/issues/2006, it's basically the same.

The commit allows deploying flux itself in a gitops-friendly way using `helm template`, it has no effect when using `helm install` /  `helm update` etc commands.
I didn't bump chart version nor update the changelog, because I was not sure how to do it. If an issue is required, please let me know, I will create one.

I will be happy to discuss if there are questions.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
