### PR TITLE
ci: Run CVE scanning for latest release and master build

### DIFF
--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -22,3 +22,13 @@ jobs:
         uses: docker://docker.io/aquasec/trivy:latest
         with:
           args: --cache-dir /var/lib/trivy --no-progress --exit-code 1 --severity MEDIUM,HIGH,CRITICAL ${{ steps.prerelease.outputs.image }}
+      - name: Get release tag
+        id: release
+        run: |
+          TAG=$(curl -s https://registry.hub.docker.com/v2/repositories/fluxcd/flux/tags/?page_size=1|jq -r .results[].name)
+          IMAGE="fluxcd/flux:$TAG"
+          echo "::set-output name=image::$IMAGE"
+      - name: Scan release
+        uses: docker://docker.io/aquasec/trivy:latest
+        with:
+          args: --cache-dir /var/lib/trivy --no-progress --exit-code 1 --severity MEDIUM,HIGH,CRITICAL ${{ steps.release.outputs.image }}

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -1,0 +1,24 @@
+name: cve-scan
+
+on:
+  push:
+    branches:
+      - '*'
+  schedule:
+    # Every day at 8am
+    - cron: '0 8 * * *'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get prerelease tag
+        id: prerelease
+        run: |
+          TAG=$(curl -s https://registry.hub.docker.com/v2/repositories/fluxcd/flux-prerelease/tags/?page_size=1|jq -r .results[].name)
+          IMAGE="fluxcd/flux-prerelease:$TAG"
+          echo "::set-output name=image::$IMAGE"
+      - name: Scan prerelease
+        uses: docker://docker.io/aquasec/trivy:latest
+        with:
+          args: --cache-dir /var/lib/trivy --no-progress --exit-code 1 --severity MEDIUM,HIGH,CRITICAL ${{ steps.prerelease.outputs.image }}

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -1,15 +1,12 @@
 name: cve-scan
 
 on:
-  push:
-    branches:
-      - '*'
   schedule:
     # Every day at 8am
     - cron: '0 8 * * *'
 
 jobs:
-  scan:
+  trivy:
     runs-on: ubuntu-latest
     steps:
       - name: Get prerelease tag


### PR DESCRIPTION
This PR adds CVE scanning with trivy for Flux container images (latest release/pre-release).
The scan runs every day in GitHub Actions and should email the Flux CD team if CVEs are found.