### PR TITLE
[chart] Add support for headless service for Flux, similar to Memcached

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -255,6 +255,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `serviceAccount.annotations`                      | ``                                                   | Additional Service Account annotations
 | `clusterRole.create`                              | `true`                                               | If `false`, Flux will be restricted to the namespaces given in `allowedNamespaces` and the namespace where it is deployed
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
+| `service.createClusterIP`                                    | `true`                                          | If `false` and service type is `ClusterIP` the service will still be created, but without IP address (a.k.a. headless service).
 | `service.port`                                    | `3030`                                               | Service port to be used
 | `sync.state`                                      | `git`                                                | Where to keep sync state; either a tag in the upstream repo (`git`), or as an annotation on the SSH secret (`secret`)
 | `sync.timeout`                                    | `None`                                               | Duration after which sync operations time out (defaults to `1m`)

--- a/chart/flux/templates/service.yaml
+++ b/chart/flux/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "ClusterIP") (eq .Values.service.createClusterIP false) }}
+  clusterIP: None
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -15,6 +15,7 @@ image:
 
 service:
   type: ClusterIP
+  createClusterIP: true
   port: 3030
 
 # Specifies which namespaces flux should have access to


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [x ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [x ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->

New configuration setting for the Helm Chart to allow deployments with Headless service.

Memcached already has this feature but is not documented. This change adds the same functionality to Flux service. This PR would document the Flux part though.

Problem description: Every deployment uses by default at least 2 service IPs - one for Flux and another for Memcached. In our setup Flux is deployed for each namespace to monitor different repos for different teams. This quickly exhausts the Service IP network just for Flux, where it is not really necessary to use such Service IP. This change allows deployment with a Headless Kubernetes Service or a service without dedicated IP address.

Users affected: Not many to be honest, it seems to be a corner case. Still this PR does not change the default behaviour of the chart and only allows the new feature to be enabled only if necessary.