### PR TITLE
docs: (re-)add link to Helm Operator documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ nav:
     - Garbage collection: references/garbagecollection.md
     - Git commit signing and verification: references/git-gpg.md
     - Automated deployment of new container images: references/automated-image-update.md
-    - Integration with the Helm Operator: references/helm-operator-integration.md
     - Monitoring Flux: references/monitoring.md
   - Guides:
     - Providing your own SSH key: guides/provide-own-ssh-key.md
@@ -60,6 +59,9 @@ nav:
     - Get started using Helm: tutorials/get-started-helm.md
     - How to bootstrap Flux using Kustomize: tutorials/get-started-kustomize.md
     - Automations, locks and annotations: tutorials/driving-flux.md
+  - Helm Operator:
+    - Documentation: https://docs.fluxcd.io/projects/helm-operator/en/stable/
+    - Flux integration: references/helm-operator-integration.md
   - Frequently asked questions: faq.md
   - Troubleshooting: troubleshooting.md
   - Contributing:


### PR DESCRIPTION
Fixes #3103 

Placement of the link was a bit awkward due to the current structure of the documentation, I opted for a new menu item which highlights the Helm Operator existence, and links to both the dedicated documentation and the `HelmRelease` integration Flux has.

Open to alternatives if someone sees a better one.