### PR TITLE
Add value 'extraEnvsFrom' to Helm Chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -245,6 +245,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `dnsConfig`                                       | ``                                                   | Pod DNS config
 | `token`                                           | `None`                                               | Weave Cloud service token
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
+| `extraEnvsFrom`                                   | `[]`                                                 | Extra environment variables from a list of sources for the Flux pod(s)
 | `env.secretName`                                  | ``                                                   | Name of the secret that contains environment variables which should be defined in the Flux container (using `envFrom`)
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
 | `rbac.pspEnabled`                                 | `false`                                              | If `true`, create and use a restricted pod security policy for Flux pod(s)

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -184,8 +184,11 @@ spec:
           {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}
           {{- end }}
-          {{- if .Values.env.secretName }}
           envFrom:
+          {{- if .Values.extraEnvsFrom }}
+{{ toYaml .Values.extraEnvsFrom | indent 10 }}
+          {{- end }}
+          {{- if .Values.env.secretName }}
           - secretRef:
               name: {{ .Values.env.secretName }}
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -223,8 +223,8 @@ memcached:
     #  cpu: 100m
     #  memory: 628Mi
     requests:
-     cpu: 50m
-     memory: 64Mi
+      cpu: 50m
+      memory: 64Mi
   priorityClassName: ""
 
 ssh:
@@ -286,6 +286,12 @@ extraEnvs: []
 # extraEnvs:
 #   - name: FOO
 #     value: bar
+
+# Additional environment variables from a list of sources to set
+extraEnvsFrom: []
+# extraEnvsFrom:
+#   - configMapRef:
+#       name: special-config
 
 prometheus:
   enabled: false


### PR DESCRIPTION
It would be nice to be able to template the envFrom in the Flux container spec.

fixes https://github.com/fluxcd/flux/issues/3108