### PR TITLE
Added 3 fuzzers

### DIFF
--- a/pkg/cluster/kubernetes/resource/fuzz.go
+++ b/pkg/cluster/kubernetes/resource/fuzz.go
@@ -1,0 +1,9 @@
+package resource
+
+func Fuzz(data []byte) int {
+	_, err := ParseMultidoc(data, string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/image/fuzz.go
+++ b/pkg/image/fuzz.go
@@ -1,0 +1,9 @@
+package image
+
+func Fuzz(data []byte) int {
+	_, err := ParseRef(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/manifests/fuzz.go
+++ b/pkg/manifests/fuzz.go
@@ -1,0 +1,10 @@
+package manifests
+
+func Fuzz(data []byte) int {
+	var cf ConfigFile
+	err := ParseConfigFile(data, &cf)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
If merged, this PR adds 3 fuzzers to Flux. 

The fuzzers can be run locally and integrated into regression testing. In addition, I can confirm that they run on oss-fuzz's infrastructure, and I will be glad to integrate Flux into their platform. If accepted, Google will run these fuzzers continuously and notify maintainers via email in case of any bugs. The service is free and the project agrees to fix the bugs that oss-fuzz finds.

This PR adds new functionality but not to the core functionality. Nor does it modify the core functionality.
An issue has been raised earlier regarding fuzzing Flux (https://github.com/fluxcd/flux/issues/2390), but it has not been discussed by the community.
I do not know if these fuzzers are related to Helm Chart.

Signed-off-by: AdamKorcz <adam@adalogics.com>