### PR TITLE
[chart] Allow specifying k8s-default-namespace in the helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -250,6 +250,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
 | `rbac.pspEnabled`                                 | `false`                                              | If `true`, create and use a restricted pod security policy for Flux pod(s)
 | `allowedNamespaces`                               | `[]`                                                 | Allow flux to manage resources in the specified namespaces. The namespace flux is deployed in will always be included
+| `defaultNamespace`                                | `""`                                                 | The namespace flux should use for resources where a namespace is not specified. If none is provided here, the default namespace in kubeconfig is used
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
 | `serviceAccount.annotations`                      | ``                                                   | Additional Service Account annotations

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -198,6 +198,9 @@ spec:
           {{- if not .Values.clusterRole.create }}
           - --k8s-allow-namespace={{ join "," (append .Values.allowedNamespaces .Release.Namespace) }}
           {{- end}}
+          {{- if .Values.defaultNamespace }}
+          - --k8s-default-namespace={{ .Values.defaultNamespace }}
+          {{- end }}
           {{- if .Values.logFormat }}
           - --log-format={{ .Values.logFormat }}
           {{end}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -21,6 +21,10 @@ service:
 # Specifies which namespaces flux should have access to
 allowedNamespaces: []
 
+# Specifies which namespace flux should use for resources where a namespace is not
+# specified. If none is provided here, the default namespace in kubeconfig is used.
+defaultNamespace: ""
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
In the helm chart, allow specifying `--k8s-default-namespace` flag for fluxd - the namespace flux should use for resources where a namespace is not specified.
