### PR TITLE
Notify upstream of manifest generation error

### DIFF
--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -231,6 +231,11 @@ func (s *lastKnownSyncState) Update(ctx context.Context, oldRev, newRev string, 
 
 	// Update in-memory revision and resources
 	s.revision = newRev
+
+	// Differentiate uninitialized resource map and initialized empty map in CurrentResources()
+	if resources == nil {
+		resources = map[string]resource.Resource{}
+	}
 	s.resources = resources
 
 	s.logger.Log("state", s.state.String(), "old", oldRev, "new", newRev)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -198,15 +198,15 @@ type Commit struct {
 }
 
 type ResourceError struct {
-	ID    resource.ID
-	Path  string
-	Error string
+	ID    resource.ID `json:"id"`
+	Path  string      `json:"path"`
+	Error string      `json:"error"`
 }
 
 type ManifestGenerationError struct {
-	File    string
-	Command string
-	Error   string
+	File    string `json:"file"`
+	Command string `json:"command"`
+	Error   string `json:"error"`
 }
 
 // SyncEventMetadata is the metadata for when new a commit is synced to the cluster
@@ -221,7 +221,7 @@ type SyncEventMetadata struct {
 	// Per-resource errors
 	Errors []ResourceError `json:"errors,omitempty"`
 	// Manifest generation error
-	GenerationError *ManifestGenerationError `json:"generationErrors,omitempty"`
+	GenerationError *ManifestGenerationError `json:"generationError,omitempty"`
 	// `true` if we have no record of having synced before
 	InitialSync bool `json:"initialSync,omitempty"`
 }

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -203,6 +203,12 @@ type ResourceError struct {
 	Error string
 }
 
+type ManifestGenerationError struct {
+	File    string
+	Command string
+	Error   string
+}
+
 // SyncEventMetadata is the metadata for when new a commit is synced to the cluster
 type SyncEventMetadata struct {
 	// for parsing old events; Commits is now used in preference
@@ -214,6 +220,8 @@ type SyncEventMetadata struct {
 	Includes map[string]bool `json:"includes,omitempty"`
 	// Per-resource errors
 	Errors []ResourceError `json:"errors,omitempty"`
+	// Manifest generation error
+	GenerationError *ManifestGenerationError `json:"generationErrors,omitempty"`
 	// `true` if we have no record of having synced before
 	InitialSync bool `json:"initialSync,omitempty"`
 }


### PR DESCRIPTION
With this PR, `Daemon.Sync()` now notifies upstreams when it failed to generate manifests.
This PR adds `GenerationError` field to `SyncEventMetadata` and populates the field when `doSync()` returns an error that indicates manifest generation failure.

This PR introduces a breaking change because it adds a field to `SyncEventMetadata`.
Upstreams that assume the current `SyncEventMetadata` structure may fail to parse new events.