### PR TITLE
Emit logs when listing resources in a namespace is forbidden

### DIFF
--- a/pkg/cluster/kubernetes/sync.go
+++ b/pkg/cluster/kubernetes/sync.go
@@ -8,12 +8,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/ryanuber/go-glob"
 	"io"
 	"os/exec"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/ryanuber/go-glob"
 
 	"github.com/go-kit/kit/log"
 	"github.com/imdario/mergo"
@@ -352,6 +353,9 @@ func (c *Cluster) listAllowedResources(
 	for _, ns := range namespaces {
 		data, err := c.client.dynamicClient.Resource(gvr).Namespace(ns).List(options)
 		if err != nil {
+			if apierrors.IsForbidden(err) {
+				c.logger.Log("info", "listing resources is forbidden", "gvr", fmt.Sprintf("%v", gvr), "namespace", ns)
+			}
 			return result, err
 		}
 		result = append(result, data.Items...)


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->

With this PR, Flux daemon emits logs when listing k8s resources in a namespace (or "all namespaces") is forbidden.
This would help users know what's wrong and fix their issues.