### PR TITLE
Limit git commit message to first 10 images

### DIFF
--- a/pkg/update/automated.go
+++ b/pkg/update/automated.go
@@ -80,7 +80,7 @@ func (a *Automated) CommitMessage(result Result) string {
 			fmt.Fprintf(buf, " - %s\n", im)
 		}
 		if total > limit {
-			fmt.Fprintln(buf, " ... ")
+			fmt.Fprintln(buf, " ...")
 		}
 	}
 	return buf.String()

--- a/pkg/update/automated.go
+++ b/pkg/update/automated.go
@@ -60,19 +60,28 @@ func (a *Automated) ReleaseKind() ReleaseKind {
 func (a *Automated) CommitMessage(result Result) string {
 	images := result.ChangedImages()
 	buf := &bytes.Buffer{}
-	prefix := ""
-	switch len(images) {
+
+	switch total := len(images); total {
 	case 0: // FIXME(michael): can we get here?
 		fmt.Fprintln(buf, "Auto-release (no images)")
+
 	case 1:
-		fmt.Fprint(buf, "Auto-release ")
+		fmt.Fprintf(buf, "Auto-release %s", images[0])
+
 	default:
-		fmt.Fprintln(buf, "Auto-release multiple images")
-		fmt.Fprintln(buf)
-		prefix = " - "
-	}
-	for _, im := range images {
-		fmt.Fprintf(buf, "%s%s\n", prefix, im)
+		limit := 10
+
+		fmt.Fprintf(buf, "Auto-release multiple (%d) images\n\n", total)
+		if total > limit {
+			// Take first 10 images to keep commit message size in bounds
+			images = images[:limit]
+		}
+		for _, im := range images {
+			fmt.Fprintf(buf, " - %s\n", im)
+		}
+		if total > limit {
+			fmt.Fprintln(buf, " ... ")
+		}
 	}
 	return buf.String()
 }

--- a/pkg/update/automated.go
+++ b/pkg/update/automated.go
@@ -80,7 +80,7 @@ func (a *Automated) CommitMessage(result Result) string {
 			fmt.Fprintf(buf, " - %s\n", im)
 		}
 		if total > limit {
-			fmt.Fprintln(buf, " ...")
+			fmt.Fprintln(buf, "   ...")
 		}
 	}
 	return buf.String()

--- a/pkg/update/automated_test.go
+++ b/pkg/update/automated_test.go
@@ -1,0 +1,75 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/fluxcd/flux/pkg/resource"
+)
+
+func TestCommitMessage(t *testing.T) {
+	automated := Automated{}
+	result := Result{
+		resource.MakeID("ns", "kind", "1"): {
+			Status: ReleaseStatusSuccess,
+			PerContainer: []ContainerUpdate{
+				{Target: mustParseRef("docker.io/image:v1")},
+				{Target: mustParseRef("docker.io/image:v2")},
+				{Target: mustParseRef("docker.io/image:v3")},
+			},
+		},
+	}
+	result.ChangedImages()
+
+	actual := automated.CommitMessage(result)
+	expected := `Auto-release multiple (3) images
+
+ - docker.io/image:v1
+ - docker.io/image:v2
+ - docker.io/image:v3
+`
+	if actual != expected {
+		t.Fatalf("Expected git commit message: '%s', was '%s'", expected, actual)
+	}
+}
+
+func TestCommitMessage10Max(t *testing.T) {
+	automated := Automated{}
+	result := Result{
+		resource.MakeID("ns", "kind", "1"): {
+			Status: ReleaseStatusSuccess,
+			PerContainer: []ContainerUpdate{
+				{Target: mustParseRef("docker.io/image:v1")},
+				{Target: mustParseRef("docker.io/image:v2")},
+				{Target: mustParseRef("docker.io/image:v3")},
+				{Target: mustParseRef("docker.io/image:v4")},
+				{Target: mustParseRef("docker.io/image:v5")},
+				{Target: mustParseRef("docker.io/image:v6")},
+				{Target: mustParseRef("docker.io/image:v7")},
+				{Target: mustParseRef("docker.io/image:v8")},
+				{Target: mustParseRef("docker.io/image:v9")},
+				{Target: mustParseRef("docker.io/image:v10")},
+				{Target: mustParseRef("docker.io/image:v11")},
+			},
+		},
+	}
+	result.ChangedImages()
+
+	actual := automated.CommitMessage(result)
+	expected := `Auto-release multiple (11) images
+
+ - docker.io/image:v1
+ - docker.io/image:v10
+ - docker.io/image:v11
+ - docker.io/image:v2
+ - docker.io/image:v3
+ - docker.io/image:v4
+ - docker.io/image:v5
+ - docker.io/image:v6
+ - docker.io/image:v7
+ - docker.io/image:v8
+ ...
+`
+	if actual != expected {
+		t.Fatalf("Expected git commit message: '%s', was '%s'", expected, actual)
+	}
+}

--- a/pkg/update/automated_test.go
+++ b/pkg/update/automated_test.go
@@ -67,7 +67,7 @@ func TestCommitMessage10Max(t *testing.T) {
  - docker.io/image:v6
  - docker.io/image:v7
  - docker.io/image:v8
- ...
+   ...
 `
 	if actual != expected {
 		t.Fatalf("Expected git commit message: '%s', was '%s'", expected, actual)


### PR DESCRIPTION
In order to address error mentioned in #1857
```
ts=2020-06-16T14:06:12.217892013Z caller=loop.go:151 component=sync-loop jobID=2e650640-7405-54e9-1e77-43fa9663e01c state=done success=false err="fork/exec /usr/bin/git: argument list too long"
```

This PR will change message in case if there are over 10 docker images updated to:
```
Auto-release multiple (11) images

 - docker.io/image:v1
 - docker.io/image:v10
 - docker.io/image:v11
 - docker.io/image:v2
 - docker.io/image:v3
 - docker.io/image:v4
 - docker.io/image:v5
 - docker.io/image:v6
 - docker.io/image:v7
 - docker.io/image:v8
 ...
```

In our case issue was that after few failed attempts to commit to git repo there was large amount of automated releases to apply, which resulted in mentioned error.

I hope to merge this fix, it has high impact on our environment.
Thank you!