### PR TITLE
Remove condition restricting images to linux/amd64

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -202,10 +202,8 @@ interpret:
 		var list manifestlist.ManifestList = deserialised.ManifestList
 		// TODO(michael): is it valid to just pick the first one that matches?
 		for _, m := range list.Manifests {
-			if m.Platform.OS == "linux" && m.Platform.Architecture == "amd64" {
-				manifest, fetchErr = manifests.Get(ctx, m.Digest, digestOpt)
-				goto interpret
-			}
+			manifest, fetchErr = manifests.Get(ctx, m.Digest, digestOpt)
+			goto interpret
 		}
 		entry := ImageEntry{}
 		entry.ExcludedReason = "no suitable manifest (linux amd64) in manifestlist"


### PR DESCRIPTION
Fixes #3066
Flux does not process & cache multi-arch images without linux/amd64 image present.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
