### PR TITLE
Log even when sync fails

### DIFF
--- a/pkg/daemon/sync_test.go
+++ b/pkg/daemon/sync_test.go
@@ -620,7 +620,7 @@ func TestDoSync_WithMultidoc(t *testing.T) {
 		t.Errorf("Sync was called with a nil syncDef")
 	}
 
-    // A sync event is emitted and it only has updated workload ids
+	// A sync event is emitted and it only has updated workload ids
 	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
 	if err != nil {
 		t.Error(err)
@@ -768,4 +768,69 @@ func TestDoSync_WithErrors(t *testing.T) {
 
 	// Check 2 sync error in stats
 	checkSyncManifestsMetrics(t, len(expectedResourceIDs)-2, 2)
+}
+
+func TestDoSync_LogErrorEvent(t *testing.T) {
+	d, cleanup := daemon(t, testfiles.Files)
+	defer cleanup()
+
+	k8s.SyncFunc = func(def cluster.SyncSet) error {
+		return nil
+	}
+	ctx := context.Background()
+
+	// Add wrong manifest
+	err := d.WithWorkingClone(ctx, func(checkout *git.Checkout) error {
+		ctx, cancel := context.WithTimeout(ctx, 5000*time.Second)
+		defer cancel()
+
+		absolutePath := path.Join(checkout.Dir(), "error_manifest.yaml")
+		if err := ioutil.WriteFile(absolutePath, []byte("Manifest that must produce errors"), 0600); err != nil {
+			return err
+		}
+		commitAction := git.CommitAction{Author: "", Message: "test error commit"}
+		err := checkout.CommitAndPush(ctx, commitAction, nil, true)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.Repo.Refresh(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	syncTag := "sync"
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", fluxsync.VerifySignaturesModeNone, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	err = d.Sync(ctx, time.Now().UTC(), "HEAD", syncState)
+	if err == nil {
+		t.Error("Sync error should not be null")
+	}
+
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
+
+	if len(es) > 1 {
+		t.Errorf("Returned more than 1 message. Actual: %d", len(es))
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := es[0]
+
+	if !(e.Type == "sync" &&
+		e.LogLevel == "error" &&
+		len(e.Message) > 0 &&
+		e.StartedAt.Before(e.EndedAt)) {
+		t.Errorf("Incorrect event")
+	}
+
 }


### PR DESCRIPTION
Sync can fail for many other reasons besides the manifests not being
ok. Some of these errors could be due to some pre processing scripts
in the .flux.yaml file or some git checkout errors. This commits logs
sync erros and allows upstream log event providers to properly display
the errors

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
