### PR TITLE
Supporting git clone over ssh behind http proxy

### DIFF
--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -15,4 +15,14 @@ data:
         {{ .Values.ssh.known_hosts }}
       {{- end }}
     {{- end }}
+  config: |
+    {{- if .Values.ssh.config }}
+      {{- if contains "\n" .Values.ssh.config }}
+        {{- range $value := .Values.ssh.config | splitList "\n" }}
+          {{ print $value }}
+      {{- end }}
+      {{- else }}
+          {{ .Values.ssh.config }}
+      {{- end }}
+    {{- end }}
 {{- end -}}

--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -15,8 +15,8 @@ data:
         {{ .Values.ssh.known_hosts }}
       {{- end }}
     {{- end }}
+  {{- if .Values.ssh.config }}
   config: |
-    {{- if .Values.ssh.config }}
       {{- if contains "\n" .Values.ssh.config }}
         {{- range $value := .Values.ssh.config | splitList "\n" }}
           {{ print $value }}
@@ -24,5 +24,5 @@ data:
       {{- else }}
           {{ .Values.ssh.config }}
       {{- end }}
-    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -229,6 +229,17 @@ ssh:
   secret:
     # Annotations for the Secret
     annotations: {}
+  config: ""
+    # specify the config which would go in /root/.ssh/config file
+    # for e.g.
+  # config: |
+  #   Host github.com
+  #   ProxyCommand socat STDIO PROXY:<proxyIP>:%h:%p,proxyport=<proxyPort>,proxyauth=<username:password>
+  #   User git
+  #   Hostname ssh.github.com
+  #   Port 443
+  #   IdentityFile /etc/fluxd/ssh/identity
+
 
 kube:
   # Override for kubectl default config


### PR DESCRIPTION
This fix refers to this enhancement
#3151 

Flux, with [this](https://github.com/fluxcd/flux/pull/2279)  enhancement, flux supported git:// [git protocol](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols). However, the downside of the Git protocol is the lack of authentication. 
The git over ssh protocol works fine with till we aren't behind a corporate proxy. To make Flux we require to have those extra stanzas in the config file in the root's ssh directory in the flux container. Something similar to:
```
Host github.com
    ProxyCommand socat STDIO PROXY:<proxyIP>:%h:%p,proxyport=<proxyport>,proxyauth=<proxyAuth>
    User git
    Hostname ssh.github.com
    Port 443
    IdentityFile /etc/fluxd/ssh/identity
```