### PR TITLE
Fix use of 'lxd' and 'snapcraft' in GH action

### DIFF
--- a/.github/workflows/fluxctl-snap.yaml
+++ b/.github/workflows/fluxctl-snap.yaml
@@ -20,7 +20,7 @@ jobs:
           use_lxd: true
 
       - name: Run Snapcraft build
-        run: sudo snapcraft --use-lxd
+        run: sg lxd -c 'snapcraft --use-lxd'
 
       - name: Upload to Snapcraft store (edge channel for revs in master)
         if: ${{ ! startsWith(github.event.ref, 'refs/tags') }}


### PR DESCRIPTION
Apparently things have changed, so I'm following the docs here to make things work again:

https://github.com/samuelmeuli/action-snapcraft/commit/3bff76127d76b7f56297a7e3db859a3aa8586ccd?short_path=04c6e90
