### PR TITLE
reset sync errors on successful sync

### DIFF
--- a/pkg/cluster/kubernetes/sync.go
+++ b/pkg/cluster/kubernetes/sync.go
@@ -116,14 +116,15 @@ func (c *Cluster) Sync(syncSet cluster.SyncSet) error {
 		errs = append(errs, deleteErrs...)
 	}
 
+	// It is expected that Cluster.Sync is invoked with *all* resources.
+	// Otherwise it will override previously recorded sync errors.
+	c.setSyncErrors(errs)
+
 	// If `nil`, errs is a cluster.SyncError(nil) rather than error(nil), so it cannot be returned directly.
 	if errs == nil {
 		return nil
 	}
 
-	// It is expected that Cluster.Sync is invoked with *all* resources.
-	// Otherwise it will override previously recorded sync errors.
-	c.setSyncErrors(errs)
 	return errs
 }
 


### PR DESCRIPTION
 This PR resets the `syncErrors` field on successful syncs.

I started playing with flux and almost immediately noticed an unexpected behavior:
- Flux syncs a few objects and some of them fail for expected reasons.
- In every future sync, flux tries to apply the failed objects individually.
- A commit is made which makes the failed objects sync successfully.

At this point, I would expect flux to stop applying the previously failed objects individually, but it doesn't because the objects are still in `Cluster`'s `syncErrors` map. They would only be cleared once the sync fails again.

Am I missing something basic here?