### PR TITLE
Fix dockercfg mountPath

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
           - name: docker-credentials
-            mountPath: /dockercfg/
+            mountPath: /dockercfg/config.json 
             readOnly: true
           {{- end }}
           {{- if .Values.gpgKeys.secretName }}


### PR DESCRIPTION
https://github.com/fluxcd/flux/issues/3058
make default dockercfg mountPath the same as default value registry.dockercfg.configFileName

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
