### PR TITLE
Add the --git-ci-skip-message parameter.

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -221,7 +221,8 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.signingKey`                                  | `None`                                               | If set, commits will be signed with this GPG key
 | `git.verifySignatures`                            | `false`                                              | If set, the signatures of the sync tag and commits will be verified
 | `git.label`                                       | `flux-sync`                                          | Label to keep track of sync progress, used to tag the Git branch
-| `git.ciSkip`                                      | `false`                                              | Append "[ci skip]" to commit messages so that CI will skip builds
+| `git.ciSkip.enabled`                              | `false`                                              | Append "[ci skip]" to commit messages so that CI will skip builds
+| `git.ciSkip.message`                              | ``                                                   | If set, fluxd will append this to commit messages (overrides "[ci skip]")
 | `git.pollInterval`                                | `5m`                                                 | Period at which to poll git repo for new commits
 | `git.timeout`                                     | `20s`                                                | Duration after which git operations time out
 | `git.secretName`                                  | `None`                                               | Kubernetes secret with the SSH private key. Superseded by `helmOperator.git.secretName` if set.

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -227,7 +227,10 @@ spec:
           - --git-poll-interval={{ .Values.git.pollInterval }}
           - --git-timeout={{ .Values.git.timeout }}
           - --sync-interval={{ .Values.sync.interval | default .Values.git.pollInterval }}
-          - --git-ci-skip={{ .Values.git.ciSkip }}
+          - --git-ci-skip={{ .Values.git.ciSkip.enabled }}
+          {{- if .Values.git.ciSkip.enabled }}
+          - --git-ci-skip-message={{ .Values.git.ciSkip.message }}
+          {{- end }}
           {{- if .Values.git.label }}
           - --git-label={{ .Values.git.label }}
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -118,7 +118,10 @@ git:
   # Label to keep track of sync progress
   label:
   # Append "[ci skip]" to commit messages so that CI will skip builds
-  ciSkip: false
+  ciSkip:
+    enabled: false
+    # If set, fluxd will append this to commit messages (overrides "[ci skip]")
+    message: ""
   # Period at which to poll git repo for new commits
   pollInterval: "5m"
   # Duration after which git operations time out


### PR DESCRIPTION
This changes will include the `--git-ci-skip-message` parameter into the helm chart.

Signed-off-by: Manuel Morejon <manuel@mmorejon.io>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
