### PR TITLE
Disable Snapcraft job

### DIFF
--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 8 * * *'
 
 jobs:
-  trivy:
+  scan-prerelease:
     runs-on: ubuntu-latest
     steps:
       - name: Get prerelease tag
@@ -19,6 +19,9 @@ jobs:
         uses: docker://docker.io/aquasec/trivy:latest
         with:
           args: --cache-dir /var/lib/trivy --no-progress --exit-code 1 --severity MEDIUM,HIGH,CRITICAL ${{ steps.prerelease.outputs.image }}
+  scan-release:
+    runs-on: ubuntu-latest
+    steps:
       - name: Get release tag
         id: release
         run: |

--- a/.github/workflows/fluxctl-snap.yaml
+++ b/.github/workflows/fluxctl-snap.yaml
@@ -3,7 +3,7 @@ name: Build snap
 on:
   push:
     branches:
-      - master
+      - disabled
 
 jobs:
   build-snap:


### PR DESCRIPTION
Disabling snap job until #3159 fixes it.
Scan releases and prereleases on dedicated jobs for better notifications.