### PR TITLE
Put git messages into tmp files

### DIFF
--- a/pkg/update/automated.go
+++ b/pkg/update/automated.go
@@ -69,18 +69,9 @@ func (a *Automated) CommitMessage(result Result) string {
 		fmt.Fprintf(buf, "Auto-release %s", images[0])
 
 	default:
-		limit := 10
-
 		fmt.Fprintf(buf, "Auto-release multiple (%d) images\n\n", total)
-		if total > limit {
-			// Take first 10 images to keep commit message size in bounds
-			images = images[:limit]
-		}
 		for _, im := range images {
 			fmt.Fprintf(buf, " - %s\n", im)
-		}
-		if total > limit {
-			fmt.Fprintln(buf, "   ...")
 		}
 	}
 	return buf.String()

--- a/pkg/update/automated_test.go
+++ b/pkg/update/automated_test.go
@@ -15,32 +15,6 @@ func TestCommitMessage(t *testing.T) {
 				{Target: mustParseRef("docker.io/image:v1")},
 				{Target: mustParseRef("docker.io/image:v2")},
 				{Target: mustParseRef("docker.io/image:v3")},
-			},
-		},
-	}
-	result.ChangedImages()
-
-	actual := automated.CommitMessage(result)
-	expected := `Auto-release multiple (3) images
-
- - docker.io/image:v1
- - docker.io/image:v2
- - docker.io/image:v3
-`
-	if actual != expected {
-		t.Fatalf("Expected git commit message: '%s', was '%s'", expected, actual)
-	}
-}
-
-func TestCommitMessage10Max(t *testing.T) {
-	automated := Automated{}
-	result := Result{
-		resource.MakeID("ns", "kind", "1"): {
-			Status: ReleaseStatusSuccess,
-			PerContainer: []ContainerUpdate{
-				{Target: mustParseRef("docker.io/image:v1")},
-				{Target: mustParseRef("docker.io/image:v2")},
-				{Target: mustParseRef("docker.io/image:v3")},
 				{Target: mustParseRef("docker.io/image:v4")},
 				{Target: mustParseRef("docker.io/image:v5")},
 				{Target: mustParseRef("docker.io/image:v6")},
@@ -67,7 +41,7 @@ func TestCommitMessage10Max(t *testing.T) {
  - docker.io/image:v6
  - docker.io/image:v7
  - docker.io/image:v8
-   ...
+ - docker.io/image:v9
 `
 	if actual != expected {
 		t.Fatalf("Expected git commit message: '%s', was '%s'", expected, actual)


### PR DESCRIPTION
Unfortunately #3140 was not enough to fix problem.

This PR will partially revert #3140 and also put git message for `git commit` and `git note` into TMP files. Preventing `args too long` error.