### PR TITLE
Avoid panic when directory does not exist

### DIFF
--- a/pkg/cluster/kubernetes/resource/load_test.go
+++ b/pkg/cluster/kubernetes/resource/load_test.go
@@ -362,3 +362,15 @@ func TestLoadSomeWithSopsAllEncrypted(t *testing.T) {
 		assert.NotNil(t, objs[expected.String()], "expected to find %s in manifest map after decryption", expected)
 	}
 }
+
+func TestNoPanic(t *testing.T) {
+	dir, cleanup := testfiles.TempDir(t)
+	defer cleanup()
+	if err := testfiles.WriteTestFiles(dir, testfiles.Files); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir, []string{filepath.Join(dir, "doesnotexist")}, true)
+	if err == nil {
+		t.Error("expected error (but not panic) when loading from directory that doesn't exist")
+	}
+}


### PR DESCRIPTION
The PR #1559 rearranged the filesystem walk during Load, so that it
only resulted in an error if there was a problem reading a YAML file
or non-chart directory (which might contain YAML files).

To decide whether a file is of interest, it first checks the stat to
see if it's a directory (in which case, recurse if not a chart ..) --
but if there's an error, that will be nil, and it will panic.

In general, you don't know if the file you can't read is (supposed to
be) a directory or a regular file, so there's no way to treat those
differently. Instead, this commit makes it check before walking that
the path supplied exists, then during the walk, ignore errors unless
it looks like a YAML file.

Fixes #3191.