### PR TITLE
chart: add kube.externalConfig option

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -267,6 +267,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `memcached.nodeSelector`                          | `{}`                                                 | Node Selector properties for the memcached deployment
 | `memcached.tolerations`                           | `[]`                                                 | Tolerations properties for the memcached deployment
 | `memcached.priorityClassName`                     | `""`                                                 | The name of the priority class to assign to the memcached pod.
+| `kube.externalConfig`                             | `false`                                              | If enabled, no kubeconfig and env var pointing to the kubeconfig will be created. You need to provide both on your own.
 | `kube.config`                                     | [See values.yaml][kubeconfig-ref]                    | Override for kubectl default config in the Flux pod(s).
 | `priorityClassName`                               | `""`                                                 | Set priority class for Flux
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -44,9 +44,11 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       volumes:
+      {{- if not .Values.kube.externalConfig }}
       - name: kubedir
         configMap:
           name: {{ template "flux.fullname" . }}-kube-config
+      {{- end }}
       {{- if .Values.ssh.known_hosts }}
       - name: sshdir
         configMap:
@@ -129,8 +131,10 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 5
           volumeMounts:
+          {{- if not .Values.kube.externalConfig }}
           - name: kubedir
             mountPath: /root/.kubectl
+          {{- end }}
           {{- if .Values.ssh.known_hosts }}
           - name: sshdir
             mountPath: /root/.ssh

--- a/chart/flux/templates/kube.yaml
+++ b/chart/flux/templates/kube.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.kube.externalConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -27,3 +28,4 @@ data:
     {{ .Values.kube.config }}
       {{- end }}
     {{- end }}
+{{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -242,6 +242,9 @@ ssh:
 
 
 kube:
+  # Disable KUBECONFIG env var and passing the default config into the Container
+  # This means you need to provide both on your own, by using extraVars and ExtraVolume(Mounts)
+  externalConfig: false
   # Override for kubectl default config
   config: |
     apiVersion: v1


### PR DESCRIPTION
This Flags adds the Option to skip the generation of an default
kubeconfig and KUBECONFIG ENV Var to provide both on your own.
This enables for example bringing in a kubeconfig from an external
secret via ExtraEnv and ExtraVolumes/Mounts


- [x] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?

- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
--> This is a niche use-case.
We basically use Flux in conjunction with Cluster API and use flux to do inital provisioning and updatesof stuff like the CNI and other Flux instances. We basically have everything encapsulated in Helm charts and are consuming Flux as a subchart in our Cluster chart. At that point Cluster-API only outputs the kubeconfig as secret which we currently cant use with the Flux Helm chart, only with an self-templated deployment which is not Ideal.
This PR basically adds ne necassesary featureflag for us to use the Flux helm chart and not having to maintain a fork of just this one feature-flag.
