### PR TITLE
Introduce advanced templating for use as subchart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -301,3 +301,30 @@ Update Flux version with:
 helm upgrade --reuse-values flux fluxcd/flux \
 --set image.tag=1.17.1
 ```
+
+### Use as a subchart
+
+This chart allows certain variables to be centrally declared in the umbrella chart and then resused in the [subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/).
+
+example:
+```yaml
+global:
+   git:
+      url: "your_git_host.example.com"
+
+umbrellachart:
+   git-url: "{{ .Values.global.git.url }}"
+
+flux:
+   git:
+      url: "{{ .Values.global.git.url }}"
+```
+
+This is currently possible for this variables:
+* extraVolumes
+* git.url
+* git.branch
+* git.path
+* git.readonly
+* git.user
+* git.email

--- a/chart/flux/templates/_helpers.tpl
+++ b/chart/flux/templates/_helpers.tpl
@@ -84,3 +84,15 @@ Create the name of the Git config Secret.
 {{- end -}}
 {{- end }}
 {{- end }}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "flux.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "flux.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           defaultMode: 0400
       {{- end }}
       {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 6 }}
+{{ include "flux.tplValue" ( dict "value"  .Values.extraVolumes "context" $) | indent 6 }}
       {{- end }}
 {{- if .Values.initContainers }}
       initContainers:
@@ -203,12 +203,12 @@ spec:
           {{- if .Values.memcached.createClusterIP }}
           - --memcached-service=
           {{- end }}
-          - --git-url={{ .Values.git.url }}
-          - --git-branch={{ .Values.git.branch }}
-          - --git-path={{ .Values.git.path }}
-          - --git-readonly={{ .Values.git.readonly }}
-          - --git-user={{ .Values.git.user }}
-          - --git-email={{ .Values.git.email }}
+          - --git-url={{ include "flux.tplValue" ( dict "value" .Values.git.url "context" $) }}
+          - --git-branch={{ include "flux.tplValue" ( dict "value" .Values.git.branch "context" $) }}
+          - --git-path={{ include "flux.tplValue" ( dict "value" .Values.git.path "context" $) }}
+          - --git-readonly={{ include "flux.tplValue" ( dict "value" .Values.git.readonly "context" $) }}
+          - --git-user={{ include "flux.tplValue" ( dict "value" .Values.git.user "context" $) }}
+          - --git-email={{ include "flux.tplValue" ( dict "value" .Values.git.email "context" $) }}
           {{- if (and .Values.gpgKeys.secretName .Values.gpgKeys.configMapName) }}
           - --git-gpg-key-import=/root/gpg-import/private,/root/gpg-import/public
           {{- else if .Values.gpgKeys.secretName }}


### PR DESCRIPTION
This introduces advanced templating that allowsyou to easier use the Flux chart as a subchart in another helm v2 Chart.
This shouldn't break anything as tpl already is a supported feature with Helm 2.
It adds the benefit that the usage of flux as a subcharts becomes easier as you can now reference global values within your values.yaml, thus you dont need to define the same value multiple times and can just crossreference it.
Example:

```yaml
global:
  tenant:
    name: tenant_1
    environment: packet
    git: "git.example.com"
    token: "somethingCryptic"
    clustername: "workload-cluster-1"

flux:
  git:
    url: https://x-access-token:{{ .Values.global.tenant.token }}@{{ .Values.global.tenant.git }}/schiff/platform/infrastructure/alpha3-environments.git
    branch: "master"
    path: "platform/tenantClusterComponents/{{ .Values.global.tenant.environment }}/{{ .Values.global.tenant.name }}/{{ .Values.global.tenant.clustername }}/core-components"
    user: "{{ .Values.global.tenant.clustername }}-flux"
    email: "{{ .Values.global.tenant.clustername }}-flux@clusters.das-schiff.telekom.de"
```
Addendum:
imo it doesnt make sense to introduce this to every option, as you propably wont overwrite many of the values from your umbrella chart. This PR basically just introduces what /we/ needed, but im sure that there are other values where it also would make sense to switch to this style.