### PR TITLE
Dockerfile: Include /sbin dir in PATH

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -36,7 +36,7 @@ ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
 COPY --from=squaremo/kubeyaml:0.7.0 /usr/lib/kubeyaml /usr/lib/kubeyaml/
-ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
+ENV PATH=/bin:/sbin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 # Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
 # This resolves the conflict between:


### PR DESCRIPTION
When trying to install additional tools in the Dockerfile of a custom image based on the Flux image. 
Example:
```dockerfile
FROM docker.io/fluxcd/flux:1.20.0
RUN apk add --no-cache jq && apk add --no-cache gettext
```
You get this: 
```
/bin/sh: apk: not found
```
A workaround is to set the PATH before like this:
```dockerfile
FROM docker.io/fluxcd/flux:1.20.0
ENV PATH=/bin:/sbin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
RUN apk add --no-cache jq && apk add --no-cache gettext
RUN wget -q -O /usr/bin/yq $(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.assets[] | select(.name == "yq_linux_amd64") | .browser_download_url') \
    && chmod +x /usr/bin/yq
```
With this change, I don't have to set the PATH in the Dockerfile
