### PR TITLE
Add envsubst package to docker image

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -4,12 +4,13 @@ WORKDIR /home/flux
 
 RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.24.2' 'gnutls>=3.6.7' 'glib>=2.62.5-r0' gnupg gawk socat
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing git-secret
+RUN set -o pipefail && apk add --no-cache libintl && apk add --no-cache --virtual build_deps gettext && cp /usr/bin/envsubst /usr/local/bin/envsubst && apk del build_deps
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
 ADD ./known_hosts.sh /home/flux/known_hosts.sh
 RUN sh /home/flux/known_hosts.sh /etc/ssh/ssh_known_hosts && \
-    rm /home/flux/known_hosts.sh
+  rm /home/flux/known_hosts.sh
 
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config
@@ -20,17 +21,17 @@ COPY ./sops /usr/local/bin
 
 # These are pretty static
 LABEL maintainer="Flux CD <https://github.com/fluxcd/flux/issues>" \
-      org.opencontainers.image.title="flux" \
-      org.opencontainers.image.description="The GitOps operator for Kubernetes" \
-      org.opencontainers.image.url="https://github.com/fluxcd/flux" \
-      org.opencontainers.image.source="git@github.com:fluxcd/flux" \
-      org.opencontainers.image.vendor="Flux CD" \
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.name="flux" \
-      org.label-schema.description="The GitOps operator for Kubernetes" \
-      org.label-schema.url="https://github.com/fluxcd/flux" \
-      org.label-schema.vcs-url="git@github.com:fluxcd/flux" \
-      org.label-schema.vendor="Flux CD"
+  org.opencontainers.image.title="flux" \
+  org.opencontainers.image.description="The GitOps operator for Kubernetes" \
+  org.opencontainers.image.url="https://github.com/fluxcd/flux" \
+  org.opencontainers.image.source="git@github.com:fluxcd/flux" \
+  org.opencontainers.image.vendor="Flux CD" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.name="flux" \
+  org.label-schema.description="The GitOps operator for Kubernetes" \
+  org.label-schema.url="https://github.com/fluxcd/flux" \
+  org.label-schema.vcs-url="git@github.com:fluxcd/flux" \
+  org.label-schema.vendor="Flux CD"
 
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
@@ -55,6 +56,6 @@ ARG VCS_REF
 
 # These will change for every build
 LABEL org.opencontainers.image.revision="$VCS_REF" \
-      org.opencontainers.image.created="$BUILD_DATE" \
-      org.label-schema.vcs-ref="$VCS_REF" \
-      org.label-schema.build-date="$BUILD_DATE"
+  org.opencontainers.image.created="$BUILD_DATE" \
+  org.label-schema.vcs-ref="$VCS_REF" \
+  org.label-schema.build-date="$BUILD_DATE"


### PR DESCRIPTION
This PR adds the `envsubst` command to the _Docker_ image to enable automation users to work around the limitations (by design) of `kustomize`.

This resolves https://github.com/fluxcd/flux/issues/3138.
