### PR TITLE
retain the error when appending the stderr output

### DIFF
--- a/pkg/cluster/kubernetes/sync.go
+++ b/pkg/cluster/kubernetes/sync.go
@@ -600,7 +600,7 @@ func (c *Kubectl) doCommand(logger log.Logger, r io.Reader, args ...string) erro
 	begin := time.Now()
 	err := cmd.Run()
 	if err != nil {
-		err = errors.Wrap(errors.New(strings.TrimSpace(stderr.String())), "running kubectl")
+		err = fmt.Errorf("running kubectl: %w, stderr: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
 	logger.Log("cmd", "kubectl "+strings.Join(args, " "), "took", time.Since(begin), "err", err, "output", strings.TrimSpace(stdout.String()))


### PR DESCRIPTION
This PR retains the Go error in `sync.go:603` which should help debugging why flux fails synchronising in #3217

