### PR TITLE
Do not return error when failed to load last-synced resources

### DIFF
--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -48,7 +48,8 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	// Load last-synced resources for comparison
 	lastResources, err := d.getLastResources(ctx, rat)
 	if err != nil {
-		return errors.Wrap(err, "loading last-synced resources")
+		d.Logger.Log("warning", "failed to load last-synced resources. sync event may be inaccurate", "err", err)
+		lastResources = map[string]resource.Resource{}
 	}
 
 	// Retrieve change set of commits we need to sync


### PR DESCRIPTION
This PR is a mitigation for a bug described in #3184 .
With this PR merged, Flux will emit warning log and not return error when it fails to load last-synced resources.

cc @squaremo 