### PR TITLE
Add a secretDataKey parameter to the Flux Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -45,6 +45,41 @@ helm repo add fluxcd https://charts.fluxcd.io
    kubectl create namespace flux
    ```
 
+1. **Optional** Create and store a deploy key in a Kubernetes secret:
+
+   At startup Flux generates a SSH key pair and stores the private key in a Kubernetes secret.
+   Flux will log the public key at startup and you will then need to add the public key as a
+   deploy key on your GitHub repository (see below).  However, this can be onerous if you're
+   deploying Flux to multiple clusters from the same repository or installing Flux multiple
+   times.
+
+   If you wish to supply your own deploy key instead, you'll need to create the Kubernetes
+   secret yourself.  You can then set the name and data key of your secret when you start Flux
+   using Helm in the next step.
+
+   > **Note:** Don't check these key files into your Git repository!
+
+   ```sh
+   # 1. Generate a SSH key named identity:
+   ssh-keygen -q -N "" -f ./identity
+
+   # 2. Create a Kubernetes secret:
+   kubectl -n flux create secret generic flux-ssh --from-file=./identity
+
+   #   2a. The SSH key will be stored in a data key matching the file name.
+   #       Set the `git.secretDataKey` value to change the data key if
+   #       you want to use a different source file.
+
+   # 3. Don't check this key into your Git repository!
+   #    To delete the private key after you've created the secret above:
+   rm ./identity
+
+   # 4. Add the contents of ./identity.pub as a deployment key with write access in your
+   #    Git repo
+
+   # 5. Set the git.secretName and git.secretDataKey fields when you call Helm below!
+   ```
+
 1. Replace `fluxcd/flux-get-started` with your own git repository and run helm install:
 
    ```sh
@@ -53,13 +88,25 @@ helm repo add fluxcd https://charts.fluxcd.io
    --namespace flux
    ```
 
+   > **Note:** if you've defined your own deploy key secret you must set the secret name and
+   (optionally) data key as Helm values.
+
+   ```sh
+   helm upgrade -i flux fluxcd/flux \
+   --set git.url=git@github.com:fluxcd/flux-get-started \
+   --set git.secretName=flux-ssh \
+   --set git.secretDataKey=deploy-key \
+   --namespace flux
+   ```
+
 1. Setup Git deploy
 
-   > **Note:** this not required when [using git over HTTPS](#flux-with-git-over-https).
+   > **Note:** this not required if you created your own deploy key or if you're
+   [using git over HTTPS](#flux-with-git-over-https) as described below.
 
-   At startup Flux generates a SSH key and logs the public key. Find the
-   SSH public key by installing [fluxctl](https://docs.fluxcd.io/en/stable/references/fluxctl)
-   and running:
+   If you haven't supplied your own deploy key, Flux generates an SSH key and logs the public
+   key at startup.  You can obtain the SSH public key by installing
+   [fluxctl](https://docs.fluxcd.io/en/stable/references/fluxctl) and running:
 
    ```sh
    fluxctl identity --k8s-fwd-ns flux
@@ -225,6 +272,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.pollInterval`                                | `5m`                                                 | Period at which to poll git repo for new commits
 | `git.timeout`                                     | `20s`                                                | Duration after which git operations time out
 | `git.secretName`                                  | `None`                                               | Kubernetes secret with the SSH private key. Superseded by `helmOperator.git.secretName` if set.
+| `git.secretDataKey`                               | `identity`                                           | The data key in the Kubernetes secret with the SSH private key. Superseded by `helmOperator.git.secretDataKey` if set.  Flux will read the SSH private key from this data key in the Kubernetes secret optionally set by the `git.secretName` value above.
 | `git.secret.enabled`                              | `false`                                              | If set and a `.gitsecret` directory exist in the root of the git repository, Flux will execute a `git secret reveal -f` in the working clone before performing any operations
 | `git.config.enabled`                              | `false`                                              | Mount `$HOME/.gitconfig` via Secret into the Flux and HelmOperator Pods, allowing for custom global Git configuration
 | `git.config.secretName`                           | `Computed`                                           | Kubernetes secret with the global Git configuration

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -199,7 +199,9 @@ spec:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --ssh-keygen-format={{ .Values.ssh.keygen.format }}
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
+          {{- if .Values.git.secretDataKey }}
           - --k8s-secret-data-key={{ .Values.git.secretDataKey | default (printf "identity" ) }}
+          {{ - end }}
           - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}
           {{- if .Values.sync.timeout }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -199,6 +199,7 @@ spec:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --ssh-keygen-format={{ .Values.ssh.keygen.format }}
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
+          - --k8s-secret-data-key={{ .Values.git.secretDataKey | default (printf "identity" ) }}
           - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}
           {{- if .Values.sync.timeout }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
           - --ssh-keygen-format={{ .Values.ssh.keygen.format }}
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
           {{- if .Values.git.secretDataKey }}
-          - --k8s-secret-data-key={{ .Values.git.secretDataKey | default (printf "identity" ) }}
+          - --k8s-secret-data-key={{ .Values.git.secretDataKey }}
           {{- end }}
           - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
           {{- if .Values.git.secretDataKey }}
           - --k8s-secret-data-key={{ .Values.git.secretDataKey | default (printf "identity" ) }}
-          {{ - end }}
+          {{- end }}
           - --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
           - --sync-state={{ .Values.sync.state }}
           {{- if .Values.sync.timeout }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -125,12 +125,24 @@ git:
   timeout: "20s"
   # The secret name can be used to supply your own SSH key, instead of
   # relying on Flux to generate one for you:
-  # 1. Generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
-  # 2. Create a Kubernetes secret: kubectl -n flux create secret generic flux-ssh --from-file=./identity
-  # 3. Delete the private key: rm ./identity
+  # 1. Generate a SSH key named identity:
+  #      ssh-keygen -q -N "" -f ./identity
+  # 2. Create a Kubernetes secret:
+  #      kubectl -n flux create secret generic flux-ssh --from-file=./identity
+  #   2a. The SSH key will be stored in a data key matching the file name.
+  #       Set the `git.secretDataKey` value below to change the data key if
+  #       you want to use a different source file.
+  # 3. Don't check these key files into your Git repository! Once you've created
+  #    the Kubernetes secret, Delete the private key:
+  #      rm ./identity
   # 4. Add ./identity.pub as a deployment key with write access in your Git repo
   # 5. Set the secret name (flux-ssh) below
   secretName: ""
+  # The default secret data key for storing the Git repository deploy key
+  # is "identity" which must match the filename in the steps for supplying
+  # your own SSH deploy key (see secretName above).  Use this field if you
+  # want to use your own filename and override the key above.
+  secretDataKey: "identity"
   # Enables `git-secret` support, as this makes use of known GPG keys
   # you will need to have imported the paired secret-key with one of
   # the public-keys which were used in the encryption using

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -142,7 +142,7 @@ git:
   # is "identity" which must match the filename in the steps for supplying
   # your own SSH deploy key (see secretName above).  Use this field if you
   # want to use your own filename and override the key above.
-  secretDataKey: "identity"
+  secretDataKey: ""
   # Enables `git-secret` support, as this makes use of known GPG keys
   # you will need to have imported the paired secret-key with one of
   # the public-keys which were used in the encryption using


### PR DESCRIPTION
Adding a secretDataKey parameter to the Flux Helm chart enables the user to override the default data key `identity` and thereby potentially create the secret from a file with a different name (such as id_rsa) or use a pre-existing secret that stores the key value using a different data key.

Expanding the Helm chart's documentation on the subject of ssh keys to add some clarity and cover this parameter.

resolves #3226 