### PR TITLE
feat: optional command timeout field in config file that defaults  to syncTimeout

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -73,7 +73,7 @@ type repo interface {
 func (d *Daemon) getManifestStore(r repo) (manifests.Store, error) {
 	absPaths := git.MakeAbsolutePaths(r, d.GitConfig.Paths)
 	if d.ManifestGenerationEnabled {
-		return manifests.NewConfigAware(r.Dir(), absPaths, d.Manifests)
+		return manifests.NewConfigAware(r.Dir(), absPaths, d.Manifests, d.SyncTimeout)
 	}
 	return manifests.NewRawFiles(r.Dir(), absPaths, d.Manifests), nil
 }

--- a/pkg/manifests/configaware_test.go
+++ b/pkg/manifests/configaware_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,7 @@ func setup(t *testing.T, paths []string, configs ...config) (*configAware, strin
 			ioutil.WriteFile(filepath.Join(baseDir, p, ConfigFilename), []byte(c.fluxyaml), 0600)
 		}
 	}
-	frs, err := NewConfigAware(baseDir, searchPaths, manifests)
+	frs, err := NewConfigAware(baseDir, searchPaths, manifests, time.Minute)
 	assert.NoError(t, err)
 	return frs, baseDir, cleanup
 }


### PR DESCRIPTION
Adds the ability to set an optional timeout duration for all commands that defaults to the sync timeout instead of `time.Minute`. Attempts to resolve: #3049. Keep in mind that in order to fix the issue described, the sync timeout **must be** greater than or equal to the sum of the generator command timeouts. I am open to ideas or to scraping this completely. Thanks Flux team!

Example:

```yaml
version: 1
patchUpdated:
  generators:
  - command: kustomize build .
    timeout: 3m # if field is not provided, sync timeout is used
  patchFile: flux-patch.yaml
```

Couple of other notes:

1. ~~I looked into parsing `timeout` from the config yaml as the type `time.Duration` instead of a string but the use of the `ghodss/yaml` package made that a bit confusing (for a new golang user anyway). It would have been nice to return an error in `ParseConfigFile` if an invalid duration was given instead of using the syncTimeout as a default without notice.~~

Solved by C&P this snippet: https://stackoverflow.com/a/48051946

2. I'm not super happy with adding the field `defaultTimeout` to the `configAware` struct. Open to suggestions on how to improve passing through the sync timeout.

TODO:

- [ ] Investigate better way of passing around/through sync timeout flag
- [ ] Update docs once this method of setting a command timeout per generator is approved