### PR TITLE
Bump Go to 1.14.7 fix CVE-2020-14040

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       image: ubuntu-1604:201903-01
     resource_class: large
     environment:
-      GO_VERSION: 1.13.1
+      GO_VERSION: 1.14.7
       # We don't need a GOPATH but CircleCI defines it, so we override it
       GOPATH: /home/circleci/go
       GO111MODULE: 'on'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14.x
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/flux
 
-go 1.13
+go 1.14
 
 // remove when https://github.com/docker/distribution/pull/2905 is released.
 replace github.com/docker/distribution => github.com/fluxcd/distribution v0.0.0-20190419185413-6c9727e5e5de


### PR DESCRIPTION
Update Go to 1.14.7 in CI and go.mod
