### PR TITLE
fluxctl snap requires the --classic option

### DIFF
--- a/docs/references/fluxctl.md
+++ b/docs/references/fluxctl.md
@@ -25,13 +25,13 @@ date.
 To install it, simply run:
 
 ```sh
-sudo snap install fluxctl
+sudo snap install fluxctl --classic
 ```
 
 If you would prefer to track builds from master, run
 
 ```sh
-sudo snap install fluxctl --edge
+sudo snap install fluxctl --edge --classic
 ```
 
 instead.


### PR DESCRIPTION
The snap "fluxctl" was published using the [classic confinement](https://snapcraft.io/docs/snap-confinement) and requires the `--classic` command-line option to be used while installing.

Signed-off-by: Ihor Dvoretskyi <ihor@linux.com>