### PR TITLE
Notify upstream of sync failures

### DIFF
--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -44,7 +44,20 @@ type changeSet struct {
 }
 
 // Sync starts the synchronization of the cluster with git.
-func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, rat ratchet) error {
+func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, rat ratchet) (rerr error) {
+
+	defer func() {
+		if rerr != nil {
+			d.LogEvent(event.Event{
+				Type:      event.EventSync,
+				StartedAt: started,
+				EndedAt:   time.Now().UTC(),
+				LogLevel:  event.LogLevelError,
+				Message:   rerr.Error(),
+			})
+
+		}
+	}()
 	// Load last-synced resources for comparison
 	lastResources, err := d.getLastResources(ctx, rat)
 	if err != nil {
@@ -55,7 +68,8 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	// Retrieve change set of commits we need to sync
 	changeSet, err := d.getChangeSet(ctx, rat, newRevision)
 	if err != nil {
-		return err
+		rerr = err
+		return
 	}
 
 	d.Logger.Log("info", "trying to sync git changes to the cluster", "old", changeSet.oldTagRev, "new", changeSet.newTagRev)
@@ -63,7 +77,8 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	// Load resources from the new revision
 	resourceStore, cleanup, err := d.getManifestStoreByRevision(ctx, newRevision)
 	if err != nil {
-		return errors.Wrap(err, "loading new resources")
+		rerr = errors.Wrap(err, "loading new resources")
+		return
 	}
 	defer cleanup()
 
@@ -71,7 +86,8 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	syncSetName := makeGitConfigHash(d.Repo.Origin(), d.GitConfig)
 	resources, resourceErrors, err := doSync(ctx, resourceStore, d.Cluster, syncSetName, d.Logger)
 	if err != nil {
-		return err
+		rerr = err
+		return
 	}
 
 	// Determine what resources changed and deleted during the sync
@@ -82,16 +98,19 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 	// Retrieve git notes and collect events from them
 	notes, err := d.getNotes(ctx, d.GitTimeout)
 	if err != nil {
-		return err
+		rerr = err
+		return
 	}
 	noteEvents, includesEvents, err := d.collectNoteEvents(ctx, changeSet, notes, d.GitTimeout, started, d.Logger)
 	if err != nil {
-		return err
+		rerr = err
+		return
 	}
 
 	// Report all synced commits
 	if err := logCommitEvent(d, changeSet, updatedIDs, started, includesEvents, resourceErrors, d.Logger); err != nil {
-		return err
+		rerr = err
+		return
 	}
 
 	// Report all collected events
@@ -99,19 +118,21 @@ func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string
 		if err = d.LogEvent(event); err != nil {
 			d.Logger.Log("err", err)
 			// Abort early to ensure at least once delivery of events
-			return err
+			rerr = err
+			return
 		}
 	}
 
 	// Move the revision the sync state points to
 	if ok, err := rat.Update(ctx, changeSet.oldTagRev, changeSet.newTagRev, resources); err != nil {
-		return err
+		rerr = err
+		return
 	} else if !ok {
-		return nil
+		return
 	}
 
-	err = refresh(ctx, d.GitTimeout, d.Repo)
-	return err
+	rerr = refresh(ctx, d.GitTimeout, d.Repo)
+	return
 }
 
 // getLastResources loads last-synced resources

--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -164,13 +164,13 @@ func (d *Daemon) getLastResources(ctx context.Context, rat ratchet) (map[string]
 	}
 
 	// Fist sync -- load resources from clone of currentRevision
-	lastResourcestore, cleanup, err := d.getManifestStoreByRevision(ctx, currentRevision)
+	lastResourceStore, cleanup, err := d.getManifestStoreByRevision(ctx, currentRevision)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading the repository checkout")
 	}
 	defer cleanup()
 
-	lastResources, err = lastResourcestore.GetAllResourcesByID(ctx)
+	lastResources, err = lastResourceStore.GetAllResourcesByID(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading resources from repo")
 	}

--- a/pkg/daemon/sync_test.go
+++ b/pkg/daemon/sync_test.go
@@ -832,5 +832,4 @@ func TestDoSync_LogErrorEvent(t *testing.T) {
 		e.StartedAt.Before(e.EndedAt)) {
 		t.Errorf("Incorrect event")
 	}
-
 }

--- a/pkg/daemon/sync_test.go
+++ b/pkg/daemon/sync_test.go
@@ -620,7 +620,7 @@ func TestDoSync_WithMultidoc(t *testing.T) {
 		t.Errorf("Sync was called with a nil syncDef")
 	}
 
-    // A sync event is emitted and it only has updated workload ids
+	// A sync event is emitted and it only has updated workload ids
 	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
 	if err != nil {
 		t.Error(err)
@@ -768,4 +768,69 @@ func TestDoSync_WithErrors(t *testing.T) {
 
 	// Check 2 sync error in stats
 	checkSyncManifestsMetrics(t, len(expectedResourceIDs)-2, 2)
+}
+
+func TestDoSync_LogErrorEvent(t *testing.T) {
+	d, cleanup := daemon(t, testfiles.Files)
+	defer cleanup()
+
+	k8s.SyncFunc = func(def cluster.SyncSet) error {
+		return nil
+	}
+	ctx := context.Background()
+
+	// Add wrong manifest
+	err := d.WithWorkingClone(ctx, func(checkout *git.Checkout) error {
+		ctx, cancel := context.WithTimeout(ctx, 5000*time.Second)
+		defer cancel()
+
+		absolutePath := path.Join(checkout.Dir(), "error_manifest.yaml")
+		if err := ioutil.WriteFile(absolutePath, []byte("Manifest that must produce errors"), 0600); err != nil {
+			return err
+		}
+		commitAction := git.CommitAction{Author: "", Message: "test error commit"}
+		err := checkout.CommitAndPush(ctx, commitAction, nil, true)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.Repo.Refresh(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	syncTag := "sync"
+	gitSync, _ := fluxsync.NewGitTagSyncProvider(d.Repo, syncTag, "", fluxsync.VerifySignaturesModeNone, d.GitConfig)
+	syncState := &lastKnownSyncState{logger: d.Logger, state: gitSync}
+
+	err = d.Sync(ctx, time.Now().UTC(), "HEAD", syncState)
+	if err == nil {
+		t.Error("Sync error should not be null")
+	}
+
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
+
+	if len(es) > 1 {
+		t.Errorf("Returned more than 1 message. Actual: %d", len(es))
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := es[0]
+
+	if !(e.Type == "sync" &&
+		e.LogLevel == "error" &&
+		len(e.Message) > 0 &&
+		e.StartedAt.Before(e.EndedAt)) {
+		t.Errorf("Incorrect event")
+	}
+
 }


### PR DESCRIPTION
This PR is a substitution of #3145 since the fork of #3145 was deleted.
From #3145 description:

> Sync can fail for many other reasons besides the manifests not being
> ok. Some of these errors could be due to some pre processing scripts
> in the .flux.yaml file or some git checkout errors. This commits logs
> sync erros and allows upstream log event providers to properly display
> the errors
> 
> Signed-off-by: Marcos Lilljedahl marcosnils@gmail.com 

I cherry-picked the commit of #3145 and added commits 7c84304e974f2da371c43fc1a1e33a2082284f37 to include commit info in sync failure event.
