### PR TITLE
Disable Helm linting in the release workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -17,3 +17,4 @@ jobs:
           owner: fluxcd
           repository: charts
           branch: gh-pages
+          linting: off


### PR DESCRIPTION
The latest Helm version fails linting for deprecated APIs:

```
[ERROR] templates/rbac.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRole" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRole"
```

Since we don't want to break compatibility with Kubernetes <1.17, we are disabling linting for now.
