### PR TITLE
Clarify misleading FAQ entry.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,7 +118,7 @@ should also provide a readonly SSH key; e.g., on GitHub, leave the
 
 ### Does Flux automatically sync changes back to git?
 
-No. It applies changes to git only when a Flux command or API call makes them.
+No, Flux will not update Git based on changes to the clusters performed through some other means. It applies changes to git only when a Flux command or API call makes them. For example, when [automated image updates](references/automated-image-update.md) are enabled.
 
 ### Will Flux delete resources when I remove them from git?
 


### PR DESCRIPTION
Based on user feedback, the _Does Flux automatically sync changes back to git?_ FAQ entry was misleading and led to incorrect assumptions. This new entry should better reflect the current state of Flux.