### PR TITLE
Cleanup exported repos during sync failures

### DIFF
--- a/pkg/git/export.go
+++ b/pkg/git/export.go
@@ -28,6 +28,7 @@ func (r *Repo) Export(ctx context.Context, ref string) (*Export, error) {
 		return nil, err
 	}
 	if err = checkout(ctx, dir, ref); err != nil {
+		os.RemoveAll(dir)
 		return nil, err
 	}
 	return &Export{dir}, nil

--- a/pkg/git/export_test.go
+++ b/pkg/git/export_test.go
@@ -2,6 +2,9 @@ package git
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +23,7 @@ func TestExportAtRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 	repo := NewRepo(Remote{URL: newDir}, ReadOnly)
+	defer repo.Clean()
 	if err := repo.Ready(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -33,6 +37,7 @@ func TestExportAtRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer export.Clean()
 
 	exportHead, err := refRevision(ctx, export.dir, "HEAD")
 	if err != nil {
@@ -40,5 +45,56 @@ func TestExportAtRevision(t *testing.T) {
 	}
 	if headMinusOne != exportHead {
 		t.Errorf("exported %s, but head in export dir %s is %s", headMinusOne, export.dir, exportHead)
+	}
+}
+
+func TestExportFailsCheckout(t *testing.T) {
+	newDir, cleanup := testfiles.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := createRepo(newDir, []string{"config"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := NewRepo(Remote{URL: newDir}, ReadOnly)
+	defer repo.Clean()
+	if err := repo.Ready(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	findWorkingDirs := func() map[string]bool {
+		entries, err := ioutil.ReadDir(os.TempDir())
+		if err != nil {
+			t.Fatalf("ioutil.ReadDir(%q)=%v, want no error", os.TempDir(), err)
+		}
+
+		found := make(map[string]bool, len(entries))
+		for _, e := range entries {
+			// Makes an assumption about the location a repo export will happen.
+			if strings.HasPrefix(e.Name(), "flux-working") {
+				found[e.Name()] = true
+			}
+		}
+		return found
+	}
+
+	prior := findWorkingDirs()
+
+	// Try to check out a revision that does not exist:
+	export, err := repo.Export(ctx, "0000000000000000000000000000000000000000")
+	if err == nil {
+		t.Fatal("want repo.Export(\"0000000000000000000000000000000000000000\") to fail, succeeded instead")
+	}
+	if export != nil {
+		t.Fatalf("repo.Export(\"0000000000000000000000000000000000000000\")=%+v, want nill", export)
+	}
+
+	for d := range findWorkingDirs() {
+		if !prior[d] {
+			t.Errorf("Found %q in %q - failed to cleanup when returning an error", d, os.TempDir())
+		}
 	}
 }


### PR DESCRIPTION
Several functions which generate a clone of the repo can result in the repository being left behind when an error is triggered. This shores up some of those failure paths to prevent the storage leaks.

One of our deployments of FluxCD was found to be eating up a bunch of space in the `/tmp` dir. There were many folders of like `/tmp/flux-workingXXXXXXX` that seemed to be hanging out. This seemed to be the result of Flux being able to pull the repository, but the path it was configured to read from had been removed. Each failure caused a new copy of the repository to be generated on disk. This shores up some of the exit paths to do a better job attempting to clean the data up.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
