### PR TITLE
Fix account IDs interpreted as float rather than string

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -273,10 +273,10 @@ spec:
           - --registry-ecr-region={{ .Values.registry.ecr.region }}
           {{- end }}
           {{- if .Values.registry.ecr.includeId }}
-          - --registry-ecr-include-id={{ .Values.registry.ecr.includeId }}
+          - --registry-ecr-include-id={{ .Values.registry.ecr.includeId | quote }}
           {{- end }}
           {{- if .Values.registry.ecr.excludeId }}
-          - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId }}
+          - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId | quote }}
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
           - --docker-config={{ .Values.registry.dockercfg.configFileName }}


### PR DESCRIPTION
The following intended string value is interpreted as a float in helm
```
     registry:
         ecr:
             region: eu-west-1
             includeId: 341309011865
```

Like following,

```
      --registry-ecr-region=eu-west-1
      --registry-ecr-include-id=3.41309011865e+11
```
