### PR TITLE
Fixup configmap in Git GPG documentation

### DIFF
--- a/docs/references/git-gpg.md
+++ b/docs/references/git-gpg.md
@@ -187,7 +187,7 @@ made, and lock on this revision.
 2. Create a `ConfigMap` with all trusted public keys:
 
     ```sh
-    $ kubectl create configmap generic flux-gpg-public-keys \
+    $ kubectl create configmap flux-gpg-public-keys \
      --from-file=author.asc --from-file=author2.asc --dry-run -o yaml
      apiVersion: v1
      data:


### PR DESCRIPTION
When I tried `kubectl create configmap generic [...]` I got an error. I believe the "generic" template is for secrets, not configmaps.

This is a docs-only update – I believe this was just a typo.