### PR TITLE
Adding rollout strategy variable for Flux deployment in chart

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     matchLabels:
       app: {{ template "flux.name" . }}
       release: {{ .Release.Name }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
~This PR adds the ability to configure the rollout strategy for the flux deployment. This aims to be a non-breaking change as if configuration not provided, nothing changed.~

This PR enforces the rollout strategy to `Recreate` for flux, in order to avoid two running instance when performing a rollout.