### PR TITLE
Add maintenance notice to help section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ be interested in the following:
 
 ## <a name="help"></a>Getting Help
 
-If you have any questions about Flux and continuous delivery:
+Reminder that Flux v1 is in maintenance mode. If you have any questions about Flux v2 and future migrations, these are the best ways to stay informed:
+- Join the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev).
+- Join the next talk and Q&A about Flux v2 on [Oct 19, 10:00 am PT / 18:00 GMT](https://www.meetup.com/GitOps-Community/events/273640196/)
+- Join the Flux v2 / GitOps Toolkit [community meetings](https://github.com/fluxcd/toolkit/discussions)
+
+If you have further questions about Flux or continuous delivery:
 
 - Read [the Flux docs](https://docs.fluxcd.io).
 - Invite yourself to the <a href="https://slack.cncf.io" target="_blank">CNCF community</a>


### PR DESCRIPTION
Adding more robust ways for Flux v1 users to know and connect re: Flux v2

Need repetition of Flux v1 in maintenance mode + specific ways to stay informed and connected about changes that happen each month/week.

<!--
# Notice
Flux is in maintenance mode, and it will take a bit
longer until we get around to issues and PRs.

For more information, and details about Flux's future,
see: https://github.com/fluxcd/flux/issues/3320

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
