### PR TITLE
feat: log update manifest errors

### DIFF
--- a/pkg/daemon/images.go
+++ b/pkg/daemon/images.go
@@ -43,7 +43,11 @@ func (d *Daemon) pollForNewAutomatedWorkloadImages(logger log.Logger) {
 	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
 
 	if len(changes.Changes) > 0 {
-		d.UpdateManifests(ctx, update.Spec{Type: update.Auto, Spec: changes})
+		_, err := d.UpdateManifests(ctx, update.Spec{Type: update.Auto, Spec: changes})
+		if err != nil {
+			logger.Log("error", errors.Wrap(err, "updating manifests"))
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Find it hard to describe if this is something that anyone else would love to see, but i just saw that `calculateChanges` will happily log problems related to images, but the returned error by `d.UpdateManifest` is dropped. 

Right now i'm in a situation where i can see that flux is endlessly finding new images and wants to update the manifest, but the manifest is never updated. I expect this change to give me clues of whats happening. 