### PR TITLE
sets memcached namespace as required by flux deployment

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -75,6 +75,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "flux.fullname" . }}-memcached
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "flux.name" . }}-memcached
     chart: {{ template "flux.chart" . }}


### PR DESCRIPTION
# sets memcached namespace as required by flux deployment

The deployment of helm chart requires the memcache service in the same namespace of flux deployment.
This small change sets the namespace in the service deployment.

----
https://github.com/fluxcd/flux/blob/master/chart/flux/templates/deployment.yaml#L208

```
- --memcached-hostname={{ .Values.memcached.hostnameOverride | default (printf "%s-memcached" (include "flux.fullname" .)) }}
```