### PR TITLE
fix completion

### DIFF
--- a/cmd/fluxctl/completion_cmd.go
+++ b/cmd/fluxctl/completion_cmd.go
@@ -49,13 +49,13 @@ func newCompletionCommand() *cobra.Command {
 }
 
 func runCompletionBash(out io.Writer, fluxctl *cobra.Command) error {
-	return fluxctl.GenBashCompletion(out)
+	return fluxctl.Root().GenBashCompletion(out)
 }
 
 func runCompletionZsh(out io.Writer, fluxctl *cobra.Command) error {
-	return fluxctl.GenZshCompletion(out)
+	return fluxctl.Root().GenZshCompletion(out)
 }
 
 func runCompletionFish(out io.Writer, fluxctl *cobra.Command) error {
-	return fluxctl.GenFishCompletion(out, true)
+	return fluxctl.Root().GenFishCompletion(out, true)
 }


### PR DESCRIPTION
It seems that the completion command is not working.

Actually what happens that the generated shel completion script is only generated for the "completion" command not for the root "fluxctl" command.


## Reproduce the issue

See how the generated functions tries to create a new completion for the command  "completion"
```
$ fluxctl completion bash | tail -7

if [[ $(type -t compopt) = "builtin" ]]; then
    complete -o default -F __start_completion completion
else
    complete -o default -o nospace -F __start_completion completion
fi
```

## Fix

After applying this patch , see the newly generated completion function:
```
$ ./fluxctl completion bash | tail -7

if [[ $(type -t compopt) = "builtin" ]]; then
    complete -o default -F __start_fluxctl fluxctl
else
    complete -o default -o nospace -F __start_fluxctl fluxctl
fi
```