### PR TITLE
Enable helm chart usage of hostAliases and extraContainers concurrently

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -298,12 +298,12 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8}}
+{{- end }}
 {{- if .Values.hostAliases }}
       hostAliases:
 {{ toYaml .Values.hostAliases |indent 8 }}
-{{- end }}
-{{- if .Values.extraContainers }}
-{{ toYaml .Values.extraContainers | indent 8}}
 {{- end }}
 {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}


### PR DESCRIPTION
Bug #3366

Content of extraContainers is listed below/inside pod.spec.hostAlias[] array instead of in the pod.spec.containers[] array.

Bug created by #2705 but only manifests if both options are used at the same time.

<!--
# Notice
Flux is in maintenance mode, and it will take a bit
longer until we get around to issues and PRs.

For more information, and details about Flux's future,
see: https://github.com/fluxcd/flux/issues/3320

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
