### PR TITLE
perf: set sync-timeout

### DIFF
--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -45,6 +45,9 @@ type changeSet struct {
 
 // Sync starts the synchronization of the cluster with git.
 func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, rat ratchet) error {
+	ctx, cancel := context.WithTimeout(ctx, d.SyncTimeout)
+	defer cancel()
+
 	// Load last-synced resources for comparison
 	lastResources, err := d.getLastResources(ctx, rat)
 	if err != nil {


### PR DESCRIPTION
Edit: Resolves #3278

<!--
# Notice
Flux is in maintenance mode, and it will take a bit
longer until we get around to issues and PRs.

For more information, and details about Flux's future,
see: https://github.com/fluxcd/flux/issues/3320

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
I modified `sync.go` to use `SyncTimeout` in `Daemon.Sync` function.
Because sometimes I have saw errors like this.
```
caller=loop.go:108 component=sync-loop err="loading resources from repo: 
error executing generator command \"kustomize build .\" from file \".flux.yaml\": context deadline exceeded
error output:
generated output:\n"
```