### PR TITLE
Change location of Helm repo "stable"

### DIFF
--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -11,7 +11,7 @@ function install_tiller() {
   if ! helm version > /dev/null 2>&1; then # only if helm isn't already installed
     kubectl --namespace kube-system create sa tiller
     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-    helm init --service-account tiller --upgrade --wait
+    helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --upgrade --wait
   fi
 }
 


### PR DESCRIPTION
The stable chart repo is being deprecated, but it's also moved to
https://charts.helm.sh/stable/, and the old location (built into the
Helm client) has been removed.

Fixes #3392.