### PR TITLE
Release chart 1.6.1

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.6.1 (2021-02-04)
+
+### Improvements
+
+ - Updated Flux to `1.21.1`
+   [fluxcd/flux#3393](https://github.com/fluxcd/flux/pull/3393)
+
+### Fixes
+
+ - Sets namespace on memcached service
+   [fluxcd/flux#3346](https://github.com/fluxcd/flux/pull/3346)
+
 ## 1.6.0 (2020-11-20)
 
 ### Improvements

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.21.0"
-version: 1.6.0
+appVersion: "1.21.1"
+version: 1.6.1
 kubeVersion: ">=1.9.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control


### PR DESCRIPTION
Includes a bump from Flux Daemon v1.21.0 to v1.21.1 with release notes here:

https://github.com/fluxcd/flux/blob/master/CHANGELOG.md#1211-2021-01-06

Notable changes include update from snap core18 to core20, which includes
updates that silence several CVE warnings (#2143), and a chart fix setting the
memcached service's namespace from Release.Namespace that was omitted before.

(The snap core update as I understand it has no effect on what is deployed by Helm, the snap base is for use with fluxctl.)

Signed-off-by: Kingdon Barrett <kingdon@weave.works>
