### PR TITLE
Improve ecr outside aws

### DIFF
--- a/pkg/registry/aws.go
+++ b/pkg/registry/aws.go
@@ -134,9 +134,6 @@ func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config A
 			metadataRegion, err := ec2.Region()
 			if err != nil {
 				preflightErr = err
-				if config.Regions == nil {
-					config.Regions = []string{}
-				}
 				logger.Log("error", "fetching region for AWS", "err", err)
 				return
 			}

--- a/pkg/registry/aws.go
+++ b/pkg/registry/aws.go
@@ -45,7 +45,10 @@ type AWSRegistryConfig struct {
 	BlockIDs   []string
 }
 
-func contains(strs []string, str string) bool {
+func containsOrNil(strs []string, str string) bool {
+	if strs == nil {
+		return true
+	}
 	for _, s := range strs {
 		if s == str {
 			return true
@@ -169,15 +172,10 @@ func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config A
 	regionEmbargo := map[string]time.Time{}
 
 	// should this registry be scanned?
-	var shouldScan func(string, string) bool
-	if config.AccountIDs == nil {
-		shouldScan = func(region, accountID string) bool {
-			return contains(config.Regions, region) && !contains(config.BlockIDs, accountID)
-		}
-	} else {
-		shouldScan = func(region, accountID string) bool {
-			return contains(config.Regions, region) && contains(config.AccountIDs, accountID) && !contains(config.BlockIDs, accountID)
-		}
+	shouldScan := func(region, accountID string) bool {
+		return containsOrNil(config.Regions, region) &&
+			containsOrNil(config.AccountIDs, accountID) &&
+			!containsOrNil(config.BlockIDs, accountID)
 	}
 
 	ensureCreds := func(domain, region, accountID string, now time.Time) error {


### PR DESCRIPTION
This solves https://github.com/fluxcd/flux/issues/2070

We currently ignore all ECR images if regions aren't set, and we are outside of an AWS cluster. (And do this silently and rather undocumented!)

The reasoning for this was cost saving: https://github.com/fluxcd/flux/pull/1619/commits/8ba016f849d49bbce2829e89edb5b641dfa117a2 which can be dismissed if we are outside of AWS anyway.
