### PR TITLE
[chart] Set nodeSelector with `kubernetes.io` from obsolete `beta.kubernetes.io`

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -318,7 +318,7 @@ spec:
 {{ toYaml .Values.dnsConfig | indent 8 }}
 {{- end }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -58,7 +58,7 @@ spec:
 {{ toYaml .Values.memcached.securityContext | indent 10 }}
         {{- end }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       {{- with .Values.memcached.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}


### PR DESCRIPTION
Update the nodeSelector from `beta.kubernetes.io` to `kubernetes.io` as it was reported that the beta nodeSelector is blocking some users from installing Flux v1 on GKE Autopilot.

Fixes #3470