### PR TITLE
Always honor the allowedNamespaces setting (or absence), for use with dynamically created namespaces

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
               name: {{ .Values.env.secretName }}
           {{- end }}
           args:
-          {{- if not .Values.clusterRole.create }}
+          {{- if and (not .Values.clusterRole.create) ( .Values.allowedNamespaces) }}
           - --k8s-allow-namespace={{ join "," (append .Values.allowedNamespaces .Release.Namespace) }}
           {{- end}}
           {{- if .Values.defaultNamespace }}


### PR DESCRIPTION
Found an issue where, when providing your own clusterRole, flux is not able to provision in namespaces other than it's own. The work around is to add all namespaces to the allowedNamespaces value but this change will not add that option if a clusterRole name has been provided

<!--

# ---- NOTICE -----

Flux v1 is in maintenance mode and Flux v2 is getting closer to GA.
If you want to learn about migrating to Flux v2, please review
<https://github.com/fluxcd/flux2/discussions/413>.

As it will take longer until we get around to issues and PRs in
Flux v1, we strongly recommend that you start familiarising yourself
with Flux v2: <https://toolkit.fluxcd.io/>

This means that new features will only be added after very careful
consideration, if at all. Refer to the links above for more detail.

# ---- END NOTICE -----


# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
