### PR TITLE
Skip AWS Metadata API pre-flight check when regions are passed via config

### DIFF
--- a/pkg/registry/aws.go
+++ b/pkg/registry/aws.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// For recognising ECR hosts
-	awsPartitionSuffix = ".amazonaws.com"
+	awsPartitionSuffix   = ".amazonaws.com"
 	awsCnPartitionSuffix = ".amazonaws.com.cn"
 
 	// How long AWS tokens remain valid, according to AWS docs; this
@@ -33,7 +33,7 @@ const (
 	// how long to skip refreshing a region after we've failed
 	embargoDuration = 10 * time.Minute
 
-	EKS_SYSTEM_ACCOUNT = "602401143452"
+	EKS_SYSTEM_ACCOUNT    = "602401143452"
 	EKS_SYSTEM_ACCOUNT_CN = "918309763551"
 )
 
@@ -120,27 +120,30 @@ func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config A
 					"exclude-ids", fmt.Sprintf("%v", config.BlockIDs))
 			}()
 
-			// This forces the AWS SDK to load config, so we can get
-			// the default region if it's there.
-			sess := session.Must(session.NewSessionWithOptions(session.Options{
-				SharedConfigState: session.SharedConfigEnable,
-			}))
-			// Always try to connect to the metadata service, so we
-			// can fail fast if it's not available.
-			ec2 := ec2metadata.New(sess)
-			metadataRegion, err := ec2.Region()
-			if err != nil {
-				preflightErr = err
-				if config.Regions == nil {
-					config.Regions = []string{}
+			if config.Regions != nil {
+				okToUseAWS = true
+				logger.Log("info", "using regions from local config")
+			} else {
+				// This forces the AWS SDK to load config, so we can get
+				// the default region if it's there.
+				sess := session.Must(session.NewSessionWithOptions(session.Options{
+					SharedConfigState: session.SharedConfigEnable,
+				}))
+				// Always try to connect to the metadata service, so we
+				// can fail fast if it's not available.
+				ec2 := ec2metadata.New(sess)
+				metadataRegion, err := ec2.Region()
+				if err != nil {
+					preflightErr = err
+					if config.Regions == nil {
+						config.Regions = []string{}
+					}
+					logger.Log("error", "fetching region for AWS", "err", err)
+					return
 				}
-				logger.Log("error", "fetching region for AWS", "err", err)
-				return
-			}
 
-			okToUseAWS = true
+				okToUseAWS = true
 
-			if config.Regions == nil {
 				clusterRegion := *sess.Config.Region
 				regionSource := "local config"
 				if clusterRegion == "" {


### PR DESCRIPTION
Replaces #3124

Reportedly fixes #3015

Thanks to @evq and sorry for the delay. ~I'll see if we can get this in 1.23.0.~ This is planned to be included now in 1.23.2.

Since this issue sat for a while and had lots of discussion, I had to research it again. The best summary of who is affected is here:

https://github.com/fluxcd/flux/pull/3124#issuecomment-644832582

The short version is, if you are following best-practices with EKS+IRSA, and still using Flux v1 with its image update automation feature on ECR, then it probably affects you. I don't have any reason to think there's any potential this fix could represent a breaking change.