### PR TITLE
Revert "Merge pull request #3381 from jumpeiMano/set-sync-timeout"

### DIFF
--- a/pkg/daemon/sync.go
+++ b/pkg/daemon/sync.go
@@ -45,9 +45,6 @@ type changeSet struct {
 
 // Sync starts the synchronization of the cluster with git.
 func (d *Daemon) Sync(ctx context.Context, started time.Time, newRevision string, rat ratchet) error {
-	ctx, cancel := context.WithTimeout(ctx, d.SyncTimeout)
-	defer cancel()
-
 	// Load last-synced resources for comparison
 	lastResources, err := d.getLastResources(ctx, rat)
 	if err != nil {


### PR DESCRIPTION
In #3500 a reporter indicates that one of the PRs merged into 1.22.2 was harmful, and causes orphaned data to grow the ephemeral filesystems without cleaning them up. The report says the context was already wrapped in a timeout; I have not been able to spend time to reproduce this issue or delve into the details myself yet.

If this is all correct, I will revert the bad PR and plan to have a new release out early this week.

This reverts commit cf97726492f4b2d9585ded3bd83823ba4e65b272, reversing
changes made to 5777baa0c5681565eb3a615a20a8a94961394fb0.