### PR TITLE
fix e2e tests - use the latest kind version (v0.11.1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.11.1
+          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
       - name: Restore Go cache
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
I believe that `engineerd/setup-kind` [doesn't see upgrades very often](https://github.com/engineerd/setup-kind/releases) and still installs kind 0.7.0 as the default version, as it has since January 2020. I found this snippet in the flux2 e2e workflow and I guess it's the solution. Flux now certainly depends on a later version of kind, to get the later version of Kubernetes.

(No telling why this did not apparently fail before the 1.23.0 release or chart-1.10.0, I have a feeling that will remain a mystery... maybe there is some part of the e2e which depends on specifically "what is in the latest released chart".)

It's not just one single e2e test that is failing, it's all of them. They fail before gitsrv is even ready. I got the impression that only one test failed because as soon as that suite reaches the end, it aborts everything in order to fail fast... but it looks like it's all of them, upon further inspection.

Hopefully this change helps matters some!