### PR TITLE
Use longer slice of Revision hash for ShortRevision

### DIFF
--- a/cmd/fluxctl/await.go
+++ b/cmd/fluxctl/await.go
@@ -33,7 +33,7 @@ is safe to retry operations.`)
 		update.PrintResults(stdout, result.Result, verbosity)
 	}
 	if result.Revision != "" {
-		fmt.Fprintf(stderr, "Commit pushed:\t%s\n", result.Revision[:7])
+		fmt.Fprintf(stderr, "Commit pushed:\t%s\n", result.Revision[:12])
 	}
 	if result.Result == nil {
 		fmt.Fprintf(stderr, "Nothing to do\n")
@@ -54,7 +54,7 @@ to run a sync interactively.`)
 			}
 			return err
 		}
-		fmt.Fprintf(stderr, "Commit applied:\t%s\n", result.Revision[:7])
+		fmt.Fprintf(stderr, "Commit applied:\t%s\n", result.Revision[:12])
 	}
 
 	return nil

--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -72,7 +72,7 @@ func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rev := result.Revision[:7]
+	rev := result.Revision[:12]
 	fmt.Fprintf(cmd.OutOrStderr(), "Revision of %s to apply is %s\n", gitConfig.Remote.Branch, rev)
 	fmt.Fprintf(cmd.OutOrStderr(), "Waiting for %s to be applied ...\n", rev)
 	err = awaitSync(ctx, opts.API, rev, opts.Timeout)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -174,7 +174,7 @@ func shortRevision(rev string) string {
 	if len(rev) <= 7 {
 		return rev
 	}
-	return rev[:7]
+	return rev[:12]
 }
 
 // CommitEventMetadata is the metadata for when new git commits are created


### PR DESCRIPTION
Fix #3517 

There have been several reports from groups with 10,000 commits or more in their repo that `fluxctl` has trouble when the Git SHA has a collision, because only the first 7 characters are used.

For future-proofing, I chose 12 characters. I bet 10 would be enough. We could do the birthday problem calculation to decide on an appropriate number, I just want to see if tests still all pass when I've fixed all the instances of that `[:7]` that I could find throughout the codebase, or if there might be one hidden in a dependency somewhere outside the project.