### PR TITLE
Add @kingdonb to fluxcd/flux maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,6 +4,7 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 
 In alphabetical order:
 
+Kingdon Barrett, Weaveworks <kingdon@weave.works> (github: @kingdonb, slack: Kingdon B)
 Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Michael Bridgen, Weaveworks <michael@weave.works> (github: @squaremo, slack: Michael Bridgen)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)


### PR DESCRIPTION
In conversations with @alisondy and @staceypotter in the past week, it came up that though I have worked on Flux for some time, I do not yet have a Project Maintainer status in the FluxCD org. They both suggested that it would make sense for me to be formally considered as a maintainer for Flux.

I have been working on Flux for some time now; I have previously asked for and received write access to the Flux repo, and I have been very happy to be working on Flux releases since about February. I think it makes sense to ask for this status now.

Please consider granting me the Project Maintainer role in the `fluxcd/flux` repo.

From the process guide in the Community Roles document, these are the steps:
https://github.com/fluxcd/community/blob/main/community-roles.md#maintainer

* Make a PR against the MAINTAINERS file for a fluxcd GitHub org repo (this PR)
* @-at-mention all the other current maintainers (@stefanprodan, @hiddeco and @squaremo)
* Have maintainers submit their vote by +1
* Once all maintainers in repo have +1 the pr will be reviewed by a member of the Flux Oversight Committee

For your consideration! Thank you, Kingdon Barrett