### PR TITLE
Upgrade to alpine-3.14

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.14
 
 WORKDIR /home/flux
 

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.1
 
 WORKDIR /home/flux
 

--- a/docker/Dockerfile.fluxctl
+++ b/docker/Dockerfile.fluxctl
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14
 
 WORKDIR /home/flux
 

--- a/docker/Dockerfile.fluxctl
+++ b/docker/Dockerfile.fluxctl
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.1
 
 WORKDIR /home/flux
 


### PR DESCRIPTION
This might be a bit quicker to safely review than #3515 – both are ready for merge IMHO, I have pushed a commit 2539db1db40f7b2732585428c142fbc915efaf74 that will test them e2e both merged together.

The alpine-3.12 image hasn't been updated in >14 days, and has several (low, medium, high, critical) CVEs against it that hasn't been fixed in any upstream 3.12 image. I don't know when another 3.12 image will be published by Alpine. 3.12 appears to show support on the [release branches](https://alpinelinux.org/releases/) page for almost another year, but experimentally it appears it is not getting updated and has CVEs against it for longer than the current series.

The alpine-3.14 series is the current series, and upgrading to 3.14.1 resolves all current CVEs in our build output according to Snyk today. I'd like for the next release to be clean of CVEs again, these are all recent CVEs that were not present (or were not yet disclosed) at the time the most recent image build was published, only about that long ago, Flux 1.23.2 that we pushed 13 days ago.

I think that Alpine users are expected to upgrade to 3.14.1 or greater now to receive updates for critical CVEs in the base image. No manual upgrades were necessary, but a 3.14 tag as of now does not appear to have been fixed at alpine upstream image repository. It's either this, or we have to run upgrades somewhere during the build of our image, which would change the layer profile and shape of our Flux image for downloads.

(To be clear I prefer this PR, I think this can be merged straightforward and is the next approval I need to proceed with creating a branch for the new series, this PR comes next after #3534 was merged.)