### PR TITLE
fix(repocachemanager): adding rate limit condition message

### DIFF
--- a/pkg/registry/cache/repocachemanager.go
+++ b/pkg/registry/cache/repocachemanager.go
@@ -209,7 +209,7 @@ updates:
 					return
 				}
 				switch {
-				case strings.Contains(err.Error(), "429"):
+				case strings.Contains(err.Error(), "429"), strings.Contains(err.Error(), "toomanyrequests"):
 					// abort the image tags fetching if we've been rate limited
 					warnAboutRateLimit.Do(func() {
 						c.logger.Log("warn", "aborting image tag fetching due to rate limiting, will try again later")


### PR DESCRIPTION
Signed-off-by: Felipe Peiter <felipe.peiter@wildlifestudios.com>

<!--

# ---- NOTICE -----

Flux v1 is in maintenance mode and Flux v2 is getting closer to GA.
If you want to learn about migrating to Flux v2, please review
<https://github.com/fluxcd/flux2/discussions/413>.

As it will take longer until we get around to issues and PRs in
Flux v1, we strongly recommend that you start familiarising yourself
with Flux v2: <https://toolkit.fluxcd.io/>

This means that new features will only be added after very careful
consideration, if at all. Refer to the links above for more detail.

# ---- END NOTICE -----


# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

The following short checklist can be used to make sure your PR is of good
quality, and can be merged easily:

- [ ] if it resolves an issue;
      is a reference (i.e. #1) to this issue included?
- [ ] if it introduces a new functionality or configuration flag;
      did you document this in the references or guides?
- [ ] optional but much appreciated;
      do you think many users would profit from a dedicated setting
      for this functionality in the Helm chart?
-->
Recently we've started seeing several messages related to the Dockerhub pull limit in our clusters:
```json
{"auth":"{map[]}","caller":"repocachemanager.go:226","canonical_name":"index.docker.io/connecteverything/nats-operator","component":"warmer","err":{"errors":[{"code":"TOOMANYREQUESTS","message":"You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"}]},"ref":"docker.io/connecteverything/nats-operator:0.8.0","ts":"2021-08-17T15:50:10.734988918Z"}
```

This is unexpected, as there is a specific switch case for handling rate-limiting [here](https://github.com/fluxcd/flux/blob/master/pkg/registry/cache/repocachemanager.go#L212). I checked the content of `err.Error()` and got this: `toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`.

I've added this error message as a new condition for the switch case. I've tested it already and got the expected behaviour:
```json
{"auth":"{map[]}","caller":"repocachemanager.go:216","canonical_name":"index.docker.io/tfgco/will-iam","component":"warmer","ts":"2021-08-20T17:20:46.220746763Z","warn":"aborting image tag fetching due to rate limiting, will try again later"}
```