### PR TITLE
Reset alpine:3.14.1 to alpine:3.14

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.14
 
 WORKDIR /home/flux
 

--- a/docker/Dockerfile.fluxctl
+++ b/docker/Dockerfile.fluxctl
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.14
 
 WORKDIR /home/flux
 


### PR DESCRIPTION
For a period of weeks when there were "HIGH" and "CRITICAL" security vulnerabilities flagged on the alpine:3.14 base image, the only way to get your builds to upgrade past them was to explicitly call for 3.14.1.

The alpine:3.14 base image is being upgraded again, and 3.14.2 is out. This PR removes the pin for 3.14.1, and replaces it at 3.14 (which emits this scan when observed through Snyk):

```
$ docker scan alpine:3.14

Testing alpine:3.14...

Organization:      kingdonb
Package manager:   apk
Project name:      docker-image|alpine
Docker image:      alpine:3.14
Platform:          linux/amd64
Base image:        alpine:3.14.2
Licenses:          enabled

✓ Tested 14 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```

Here is the output on Flux's latest release at current date, for reference:

```
$ docker scan fluxcd/flux:1.24.0

Testing fluxcd/flux:1.24.0...

✗ Low severity vulnerability found in openssl/libcrypto1.1
  Description: CVE-2021-3711
  Info: https://snyk.io/vuln/SNYK-ALPINE314-OPENSSL-1569445
  Introduced through: openssl/libcrypto1.1@1.1.1k-r0, openssl/libssl1.1@1.1.1k-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.78.0-r0, openldap/libldap@2.4.58-r0, openssh/openssh-client-common@8.6_p1-r2, openssh/openssh-keygen@8.6_p1-r2, openssh/openssh-client-default@8.6_p1-r2, socat/socat@1.7.4.1-r1
  From: openssl/libcrypto1.1@1.1.1k-r0
  From: openssl/libssl1.1@1.1.1k-r0 > openssl/libcrypto1.1@1.1.1k-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1k-r0
  and 14 more...
  Image layer: '/bin/sh -c apk add --no-cache openssh-client ca-certificates tini 'git>=2.24.2' 'gnutls>=3.6.7' 'glib>=2.62.5-r0' gnupg gawk socat'
  Fixed in: 1.1.1l-r0

✗ Low severity vulnerability found in openssl/libcrypto1.1
  Description: CVE-2021-3712
  Info: https://snyk.io/vuln/SNYK-ALPINE314-OPENSSL-1569449
  Introduced through: openssl/libcrypto1.1@1.1.1k-r0, openssl/libssl1.1@1.1.1k-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.78.0-r0, openldap/libldap@2.4.58-r0, openssh/openssh-client-common@8.6_p1-r2, openssh/openssh-keygen@8.6_p1-r2, openssh/openssh-client-default@8.6_p1-r2, socat/socat@1.7.4.1-r1
  From: openssl/libcrypto1.1@1.1.1k-r0
  From: openssl/libssl1.1@1.1.1k-r0 > openssl/libcrypto1.1@1.1.1k-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1k-r0
  and 14 more...
  Image layer: '/bin/sh -c apk add --no-cache openssh-client ca-certificates tini 'git>=2.24.2' 'gnutls>=3.6.7' 'glib>=2.62.5-r0' gnupg gawk socat'
  Fixed in: 1.1.1l-r0



Organization:      kingdonb
Package manager:   apk
Project name:      docker-image|fluxcd/flux
Docker image:      fluxcd/flux:1.24.0
Platform:          linux/amd64
Base image:        alpine:3.14.1
Licenses:          enabled

Tested 60 dependencies for known issues, found 2 issues.

Base Image     Vulnerabilities  Severity
alpine:3.14.1  2                0 critical, 0 high, 0 medium, 2 low

Recommendations for base image upgrade:

Minor upgrades
Base Image  Vulnerabilities  Severity
alpine:3    0                0 critical, 0 high, 0 medium, 0 low
```

This is a patch-level change, so I will plan to include it in the 1.24.1 milestone that is still upcoming, date TBD. I don't know if we are linking statically or if we use these SSL libraries, the vulnerability is marked LOW severity.

I won't make any judgment at this point on whether this means we should upgrade immediately, but I think it's fair to say that feedback from community members about whether this change is urgent for you can help influence my opinion. I don't know how close attention our users are paying to things like this, but suspect it varies widely depending on mostly who you work for and what procedures for supply chain security and container image controls you may have in place.

I will probably plan on releasing a new image with this change included either later this week, or early next week, absent any of that type of feedback with potential to be a bit later than that! If someone can show this directly affects Flux, I would be inclined to raise the urgency of the release, but right now it's not exactly clear to me if those effects are even possible.