### PR TITLE
Release 1.24.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: |
             if echo "${CIRCLE_TAG}" | grep -Eq "^[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
               # Publish binaries to GitHub
-              go get github.com/weaveworks/github-release
+              go get github.com/github-release/github-release
               make build-fluxctl
               bin/upload-binaries
 


### PR DESCRIPTION
Fix #3550 

The `weaveworks/github-release` fork appears to be pretty far behind the upstream, and is now emitting 400 errors:

https://github.com/fluxcd/flux/pull/3549 - the build failure on `3b794b7`

Mentioned this issue once before here, when this issue first hit:
https://github.com/fluxcd/flux/pull/3544#issuecomment-915646145

It seems from testing on a personal fork that these errors are resolved when the current upstream of github-release/github-release is used instead, so let's do that.