### PR TITLE
Revert "Check for allowed namespaces when providing a clusterrole"

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.11.2 (2021-09-10)
+
+Single-tenant Flux users reported a regression that affected automated image
+updates in certain configurations from this chart fix, so it is reverted to
+preserve backwards compatibility.
+
+### Fixes
+
+ - Revert [#3482](https://github.com/fluxcd/flux/pull/3482) (undo chart-1.11.0)
+   [fluxcd/flux#3553](https://github.com/fluxcd/flux/pull/3553)
+
 ## 1.11.1 (2021-09-09)
 
 ### Improvements

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.24.1"
-version: 1.11.1
+version: 1.11.2
 kubeVersion: ">=1.16.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
               name: {{ .Values.env.secretName }}
           {{- end }}
           args:
-          {{- if and (not .Values.clusterRole.create) ( .Values.allowedNamespaces) }}
+          {{- if not .Values.clusterRole.create }}
           - --k8s-allow-namespace={{ join "," (append .Values.allowedNamespaces .Release.Namespace) }}
           {{- end}}
           {{- if .Values.defaultNamespace }}


### PR DESCRIPTION
This reverts commit 2ddd7e4bcec72bb9b499c2d13fcbc74b899e0042, per discussion from #3552 and #3482.

It looks like there's a class of users who only use one namespace and do not set allowedNamespaces that are turning up now, reporting this change wasn't backwards compatible for them and stopped image automation from working anymore.