### PR TITLE
WIP: handle noisy deprecation warnings

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -421,6 +421,7 @@ func main() {
 			logger.Log("err", err)
 			os.Exit(1)
 		}
+		restClientConfig.WarningHandler = rest.NoWarnings{}
 		restClientConfig.QPS = 50.0
 		restClientConfig.Burst = 100
 	}


### PR DESCRIPTION
There is almost certainly more to do, this follows the discussion in #3554 

We would like for Flux users to be able to get their deprecation warnings through Flux logs if it's the only way they have, however we would prefer that the GC sweep does not emit deprecation warnings for resource kinds that are deprecated but aren't even used on the cluster.

I believe this PR currently only suppresses all warnings, it is WIP.