### PR TITLE
Bump image version for memcached to 1.6.12

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -208,7 +208,7 @@ memcached:
   enabled: true
   hostnameOverride:
   repository: memcached
-  tag: 1.6.10-alpine
+  tag: 1.6.12-alpine
   pullSecret:
   createClusterIP: true
   verbose: false


### PR DESCRIPTION
There is a new release of memcached, 1.6.12, which can be included in the next Flux v1 chart release.