### PR TITLE
Release chart 1.11.3

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.11.3 (2021-11-02)
+
+### Improvements
+
+ - Updated Flux to `1.24.2`
+   [fluxcd/flux#3565](https://github.com/fluxcd/flux/pull/3565)
+ - Update Memcached to `1.6.12`
+   [fluxcd/flux#3566](https://github.com/fluxcd/flux/pull/3566)
+
 ## 1.11.2 (2021-09-10)
 
 Single-tenant Flux users reported a regression that affected automated image

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.24.1"
-version: 1.11.2
+appVersion: "1.24.2"
+version: 1.11.3
 kubeVersion: ">=1.16.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -9,7 +9,7 @@ logFormat: fmt
 
 image:
   repository: docker.io/fluxcd/flux
-  tag: 1.24.1
+  tag: 1.24.2
   pullPolicy: IfNotPresent
   pullSecret:
 


### PR DESCRIPTION
This includes fluxcd/flux#3566 to upgrade Memcached to the latest patch version.

After Flux 1.24.2 image is tagged and released, via #3565, and after the housekeeping PR (~which has yet to be created~ just merged as #3568) from the `release/1.24.x` branch merges back to `master`, then:

- [X] this PR can be rebased
- and can be merged to release the chart.

(This is per usual, as documented here: [releasing.md](/fluxcd/flux/blob/master/internal/docs/releasing.md))