### PR TITLE
Required upgrade for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /home/circleci/go/src/github.com/fluxcd/flux
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202010-01
     resource_class: large
     environment:
       GO_VERSION: 1.16.7

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(ARCH),)
 endif
 CURRENT_OS=$(shell go env GOOS)
 CURRENT_OS_ARCH=$(shell echo $(CURRENT_OS)-`go env GOARCH`)
-GOBIN?=$(shell echo `go env GOPATH`/bin)
+GOBIN?=$(shell echo `go env GOPATH|cut -d: -f1`/bin)
 
 MAIN_GO_MODULE:=$(shell go list -m -f '{{ .Path }}')
 LOCAL_GO_MODULES:=$(shell go list -m -f '{{ .Path }}' all | grep $(MAIN_GO_MODULE))


### PR DESCRIPTION
Fix #3592

We are deprecating Ubuntu 16.04-based machine images on CircleCI in preparation for an EOL on Tuesday, May 31

(Replaces #3591)

The reason for a change in `Makefile` is that newer CircleCI images effectively prohibit us from overriding GOPATH in the `environment` block of `.circleci/config.yml` – the `GOPATH` is set to have two directories by default, we can't override it, and only the first is used for inferring a default `GOBIN`.

I am not certain if allowing `GOPATH` to be set as defaulted can have any other negative side-effects, but this seems to be the least impact change possible that will allow us to go on building after May 31.

Tested a few different approaches to solving this on my fork at `kingdonb/flux` and pretty much settled that other approaches have drawbacks that make this the best option. I experimented with using an orb called `persist-env` and I think that would be rejected for security concerns (though it also worked to solve the issue, when I bypassed a security warning.)

Those tests are on my personal fork, I have not bypassed any security warnings for the Flux PR to merge.