### PR TITLE
Add access to `--git-verify-signatures-mode` from Helm

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -270,6 +270,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.setAuthor`                                   | `false`                                              | If set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer.
 | `git.signingKey`                                  | `None`                                               | If set, commits will be signed with this GPG key
 | `git.verifySignatures`                            | `false`                                              | If set, the signatures of the sync tag and commits will be verified
+| `git.verifySignaturesMode`                        | ``                                                   | If set, takes precendence over verifySignatures and sets which strategy to use for signature verification (one of "all", "none", "first-parent")
 | `git.label`                                       | `flux-sync`                                          | Label to keep track of sync progress, used to tag the Git branch
 | `git.ciSkip`                                      | `false`                                              | Append "[ci skip]" to commit messages so that CI will skip builds
 | `git.pollInterval`                                | `5m`                                                 | Period at which to poll git repo for new commits

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -234,7 +234,11 @@ spec:
           {{- if .Values.git.signingKey }}
           - --git-signing-key={{ .Values.git.signingKey }}
           {{- end }}
+          {{- if .Values.git.verifySignaturesMode }}
+          - --git-verify-signatures-mode={{ .Values.git.verifySignaturesMode }}
+          {{ else }}
           - --git-verify-signatures={{ .Values.git.verifySignatures }}
+          {{ end }}
           - --git-set-author={{ .Values.git.setAuthor }}
           {{- if .Values.git.secret.enabled }}
           - --git-secret

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -116,8 +116,10 @@ git:
   email: "support@weave.works"
   # If set, commits will be signed with this GPG key.
   signingKey: ""
-  # If set, the signatures of the sync tag and commits will be verified.
+  # If set, the signatures of the sync tag and commits will be verified (deprecated)
   verifySignatures: false
+  # If set, takes precendence over verifySignatures and sets which strategy to use for signature verification (one of "all", "none", "first-parent")
+  verifySignaturesMode: ""
   # If set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer.
   setAuthor: false
   # Label to keep track of sync progress


### PR DESCRIPTION
This is retro-compatible with previous versions (won't cause a new deployment without specifically setting the config)
It allows a user to set the `--git-verify-signatures-mode` option instead of the deprecated `--git-verify-signatures` which is currently always set
