### PR TITLE
Allow RSA signatures using SHA-1 hash algorithm

### DIFF
--- a/docker/ssh_config
+++ b/docker/ssh_config
@@ -3,3 +3,5 @@ StrictHostKeyChecking yes
 IdentityFile /etc/fluxd/ssh/identity
 IdentityFile /var/fluxd/keygen/identity
 LogLevel error
+HostkeyAlgorithms +ssh-rsa
+PubkeyAcceptedAlgorithms +ssh-rsa


### PR DESCRIPTION
This was disabled by default at openssh 8.8 but is still used by some git implementations eg Azure DevOps

Fixes #3611 

Per that issue, would welcome a release containing this fix - flux 1.25.0 is meanwhile not usable for us.