### PR TITLE
Release chart 1.13.1

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.13.1 (2022-05-26)
+
+### Improvements
+
+ - Updated Flux to `1.25.2`
+   [fluxcd/flux#3615](https://github.com/fluxcd/flux/pull/3615)
+
 ## 1.13.0 (2022-05-05)
 
 ### Improvements

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.25.1"
-version: 1.13.0
+appVersion: "1.25.2"
+version: 1.13.1
 kubeVersion: ">=1.16.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -9,7 +9,7 @@ logFormat: fmt
 
 image:
   repository: docker.io/fluxcd/flux
-  tag: 1.25.1
+  tag: 1.25.2
   pullPolicy: IfNotPresent
   pullSecret:
 


### PR DESCRIPTION
Closes #3611

Rebased and merged, after the release v1.25.2 is out and now after the housekeeping PR (#3617) is merged back to `master`:

* #3615 

This PR, after it is merged, can be tagged as `chart-1.13.1` to complete the release and publish the Helm chart.