### PR TITLE
Update module github.com/prometheus/client_golang to v1.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v1.1.0
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1032,6 +1032,8 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
+github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -1050,6 +1052,8 @@ github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB8
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.30.0 h1:JEkYlQnpzrzQFxi6gnukFPdQ+ac82oRhzMcIduJu/Ug=
 github.com/prometheus/common v0.30.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
+github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -1560,6 +1564,7 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886 h1:eJv7u3ksNXoLbGSKuv2s/SIO4tJVxc/A+MTpzxDgz/Q=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=


### PR DESCRIPTION
Suggested by Renovate and Snyk, there is a medium sev reported in `prometheus/client_golang` which we could upgrade:

```
Testing fluxcd/flux:1.25.2...

✗ Medium severity vulnerability found in github.com/prometheus/client_golang/prometheus/promhttp
  Description: Denial of Service (DoS)
  Info: https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMPROMETHEUSCLIENTGOLANGPROMETHEUSPROMHTTP-2401819
  Introduced through: github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  From: github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  Fixed in: 1.11.1
```

This is just the one issue I noticed that we can do something about right away, I just decided to drop in and scope out potential changes for a next release since we are coming up on 30 days since the last one.

There are also critical reports from `pcre2/pcre2` introduced by our base image (`alpine:3.15.4`), it's not clear when a new base image patch version will be released, so if we can mitigate this manually or just check for it in the resulting build, which I'm testing out now as I submit this.

Perhaps it will be updated out without a rev in the base image, but I think we don't run `apk update` in our build process if it's not, so we may have to either change that, or wait for a new revision, and I'm inclined to just wait.

Not exactly sure how they do things at Alpine HQ to be honest, but I'm sure they're on top of this, so maybe we want to delay a release until this all can be resolved out too, (I will look for it in the test build result):

```
Testing fluxcd/flux:1.25.2...

✗ Critical severity vulnerability found in pcre2/pcre2
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE315-PCRE2-2869383
  Introduced through: pcre2/pcre2@10.39-r0, git/git@2.34.2-r0
  From: pcre2/pcre2@10.39-r0
  From: git/git@2.34.2-r0 > pcre2/pcre2@10.39-r0
  Image layer: Introduced by your base image (alpine:3.15.4)
  Fixed in: 10.40-r0

✗ Critical severity vulnerability found in pcre2/pcre2
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE315-PCRE2-2869384
  Introduced through: pcre2/pcre2@10.39-r0, git/git@2.34.2-r0
  From: pcre2/pcre2@10.39-r0
  From: git/git@2.34.2-r0 > pcre2/pcre2@10.39-r0
  Image layer: Introduced by your base image (alpine:3.15.4)
  Fixed in: 10.40-r0

✗ Critical severity vulnerability found in openldap/libldap
  Description: SQL Injection
  Info: https://snyk.io/vuln/SNYK-ALPINE315-OPENLDAP-2863511
  Introduced through: openldap/libldap@2.6.0-r0, gnupg/gpg@2.2.31-r1
  From: openldap/libldap@2.6.0-r0
  From: gnupg/gpg@2.2.31-r1 > gnupg/gnupg@2.2.31-r1 > gnupg/gnupg-dirmngr@2.2.31-r1 > openldap/libldap@2.6.0-r0
  Image layer: 'apk add --no-cache openssh-client ca-certificates tini 'git>=2.24.2' 'gnutls>=3.6.7' 'glib>=2.62.5-r0' gnupg gawk socat'
  Fixed in: 2.6.2-r0
```

The last recorded issue from the scan, which I'll mention just for completeness, is another one which I'm not sure we can do anything about, since SOPS @ `v4` must likely contain a breaking change else it would not have got a major increment, I don't know if we can adopt this upgrade or if we've already covered this in prior discussions.

(But I know the `jwt-go` vulnerability was mitigated in one of our most recent releases, thanks @pjbgf):

```
Testing fluxcd/flux:1.25.2...

✗ High severity vulnerability found in github.com/dgrijalva/jwt-go
  Description: Access Restriction Bypass
  Info: https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515
  Introduced through: github.com/dgrijalva/jwt-go@3.2.0+incompatible
  From: github.com/dgrijalva/jwt-go@3.2.0+incompatible
  Fixed in: 4.0.0-preview1



Organization:      kingdonb
Package manager:   gomodules
Target file:       /usr/local/bin/sops
Project name:      go.mozilla.org/sops/v3
Docker image:      fluxcd/flux:1.25.2
Licenses:          enabled
```

I am not in any hurry to push the release button again, just testing. 👍 